### PR TITLE
Import CSV data to olympians table in DB

### DIFF
--- a/migrations/20190603022556-create-olympian.js
+++ b/migrations/20190603022556-create-olympian.js
@@ -1,0 +1,44 @@
+'use strict';
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('olympians', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        allowNull: true,
+        type: Sequelize.STRING
+      },
+      team: {
+        allowNull: true,
+        type: Sequelize.STRING
+      },
+      age: {
+        allowNull: true,
+        type: Sequelize.INTEGER
+      },
+      sport: {
+        allowNull: true,
+        type: Sequelize.STRING
+      },
+      total_medals_won: {
+        allowNull: true,
+        type: Sequelize.INTEGER
+      },
+      createdat: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedat: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('olympians');
+  }
+};

--- a/models/olympian.js
+++ b/models/olympian.js
@@ -1,0 +1,14 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const Olympian = sequelize.define('Olympian', {
+    name: DataTypes.STRING,
+    team: DataTypes.STRING,
+    age: DataTypes.INTEGER,
+    sport: DataTypes.STRING,
+    total_medals_won: DataTypes.INTEGER
+  }, {});
+  Olympian.associate = function(models) {
+    // associations can be defined here
+  };
+  return Olympian;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,25 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
+    "arguments-extended": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/arguments-extended/-/arguments-extended-0.0.3.tgz",
+      "integrity": "sha1-YQfkkX0OtvCk3WYyD8Fa/HLvSUY=",
+      "requires": {
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.8"
+      }
+    },
+    "array-extended": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/array-extended/-/array-extended-0.0.11.tgz",
+      "integrity": "sha1-1xRK50jek8pybxIQCdv/FibRZL0=",
+      "requires": {
+        "arguments-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -223,6 +242,16 @@
         "es5-ext": "^0.10.9"
       }
     },
+    "date-extended": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/date-extended/-/date-extended-0.0.6.tgz",
+      "integrity": "sha1-I4AtV90b94GIE/4MMuhRqG2iZ8k=",
+      "requires": {
+        "array-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -235,6 +264,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "declare.js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/declare.js/-/declare.js-0.0.8.tgz",
+      "integrity": "sha1-BHit/5VkwAT1Hfc9i8E0AZ0o3N4="
     },
     "depd": {
       "version": "1.1.2",
@@ -397,6 +431,34 @@
         "vary": "~1.1.2"
       }
     },
+    "extended": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/extended/-/extended-0.0.6.tgz",
+      "integrity": "sha1-f7i/e52uOXWG5IVwrP1kLHjlBmk=",
+      "requires": {
+        "extender": "~0.0.5"
+      }
+    },
+    "extender": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/extender/-/extender-0.0.10.tgz",
+      "integrity": "sha1-WJwHSCvmGhRgttgfnCSqZ+jzJM0=",
+      "requires": {
+        "declare.js": "~0.0.4"
+      }
+    },
+    "fast-csv": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-2.5.0.tgz",
+      "integrity": "sha512-M/9ezLU9/uDwvDZTt9sNFJa0iLDUsbhYJwPtnE0D9MjeuB6DY9wRCyUPZta9iI6cSz5wBWGaUPL61QH8h92cNA==",
+      "requires": {
+        "extended": "0.0.6",
+        "is-extended": "0.0.10",
+        "object-extended": "0.0.7",
+        "safer-buffer": "^2.1.2",
+        "string-extended": "0.0.8"
+      }
+    },
     "finalhandler": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
@@ -532,6 +594,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
       "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
+    },
+    "is-extended": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
+      "integrity": "sha1-JE4UDfdbscmjEG9BL/GC+1NKbWI=",
+      "requires": {
+        "extended": "~0.0.3"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -770,6 +840,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-extended": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/object-extended/-/object-extended-0.0.7.tgz",
+      "integrity": "sha1-hP0j9WsVWCrrPoiwXLVdJDLWijM=",
+      "requires": {
+        "array-extended": "~0.0.4",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -1205,6 +1285,17 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "string-extended": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
+      "integrity": "sha1-dBlX3/SHsCcqee7FpE8jnubxfM0=",
+      "requires": {
+        "array-extended": "~0.0.5",
+        "date-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
+      }
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
     "express": "~4.16.0",
+    "fast-csv": "^2.5.0",
     "morgan": "~1.9.0",
     "pg": "^7.11.0",
     "sequelize": "^5.8.7",

--- a/public/files/olympions.csv
+++ b/public/files/olympions.csv
@@ -1,0 +1,3486 @@
+Name,Sex,Age,Height,Weight,Team,Games,Sport,Event,Medal
+Andreea Aanei,F,22,170,125,Romania,2016 Summer,Weightlifting,Weightlifting Women's Super-Heavyweight,NA
+Nstor Abad Sanjun,M,23,167,64,Spain,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Nstor Abad Sanjun,M,23,167,64,Spain,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Nstor Abad Sanjun,M,23,167,64,Spain,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Nstor Abad Sanjun,M,23,167,64,Spain,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Nstor Abad Sanjun,M,23,167,64,Spain,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Nstor Abad Sanjun,M,23,167,64,Spain,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Antonio Abadia Beci,M,26,170,65,Spain,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Giovanni Abagnale,M,21,198,90,Italy,2016 Summer,Rowing,Rowing Men's Coxless Pairs,Bronze
+Patimat Abakarova,F,21,165,49,Azerbaijan,2016 Summer,Taekwondo,Taekwondo Women's Flyweight,Bronze
+Luc Abalo,M,31,182,86,France,2016 Summer,Handball,Handball Men's Handball,Silver
+Ilyas Abbadi,M,23,175,75,Algeria,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Abubakar Abbas Abbas,M,20,175,66,Bahrain,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Lois Abbingh,F,23,178,72,Netherlands,2016 Summer,Handball,Handball Women's Handball,NA
+Salwan Jasim Abbood Abbood,M,24,180,104,Iraq,2016 Summer,Weightlifting,Weightlifting Men's Heavyweight,NA
+Clare Abbott,F,30,167,58,Ireland,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Clare Abbott,F,30,167,58,Ireland,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Mara Katherine Abbott,F,30,163,52,United States,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Hossam Abdalla,M,28,203,97,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Maha Abdalsalam Gouda,F,18,172,61,Egypt,2016 Summer,Diving,Diving Women's Platform,NA
+Ahmed Abdel Naeim,M,31,197,87,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Samy Abdel Razek,M,36,170,60,Egypt,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Samy Abdel Razek,M,36,170,60,Egypt,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Shaimaa Abdel-Latif-Hashad,F,35,165,57,Egypt,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Ahmed Abdelaal,M,27,188,89,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Mahmoud Abdelaal,M,24,176,60,Egypt,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Mohamed Ali Abdelaal,M,26,175,81,Egypt,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Ibrahim Ramadan Ibrahim Abdelbaki,M,28,173,77,Egypt,2016 Summer,Weightlifting,Weightlifting Men's Middleweight,NA
+Ragab Abdelhay Saad Abdelrazek Abdallah,M,25,170,94,Egypt,2016 Summer,Weightlifting,Weightlifting Men's Middle-Heavyweight,NA
+Ayoub Abdellaoui,M,23,184,68,Algeria,2016 Summer,Football,Football Men's Football,NA
+Leila Abdelmoez,F,19,160,46,Egypt,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Ahmed Abdelrahman,M,20,165,60,Egypt,2016 Summer,Judo,Judo Men's Extra-Lightweight,NA
+Mamdouh Abdelrehim,M,26,207,90,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Saeid Morad Abdevali,M,26,170,80,Iran,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",Bronze
+Bashir Abdi,M,27,176,56,Belgium,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Bashir Abdi,M,27,176,56,Belgium,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Fawziya Abdoulkarim,F,27,180,67,Cameroon,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Berik Abdrakhmanov,M,30,165,60,Kazakhstan,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Maizurah Abdul Rahim,F,17,147,50,Brunei,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Abdulqdir Abdullayev,M,28,188,91,Azerbaijan,2016 Summer,Boxing,Boxing Men's Heavyweight,NA
+Muminzhon Abdullayev,M,26,190,130,Uzbekistan,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Greco-Roman",NA
+Waheed Abdulridha Waheed Karaawi,M,33,178,74,Iraq,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Bekzod Makhamadzhonovich Abdurakhmonov,M,26,172,74,Uzbekistan,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Freestyle",NA
+Mukhamadmurod Abdurakhmonov,M,29,192,117,Tajikistan,2016 Summer,Judo,Judo Men's Heavyweight,NA
+Adlan Aliyevich Abdurashidov,M,26,172,60,Russia,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Mojtaba Abedini Shormasti,M,31,180,83,Iran,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Jennifer Abel,F,24,160,62,Canada,2016 Summer,Diving,Diving Women's Springboard,NA
+Jennifer Abel,F,24,160,62,Canada,2016 Summer,Diving,Diving Women's Synchronized Springboard,NA
+Arthur Abele,M,30,184,85,Germany,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Jos Javier Abella Fanjul,M,22,176,66,Mexico,2016 Summer,Football,Football Men's Football,NA
+Tesfaye Abera Dibaba,M,24,192,68,Ethiopia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Matthew Duncan Abeysinghe,M,20,180,74,Sri Lanka,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Narek Abgaryan,M,24,166,52,Armenia,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Pablo Abin Vicen,M,31,177,68,Spain,2016 Summer,Badminton,Badminton Men's Singles,NA
+"Catherine ""Kate"" Abilla Awino",F,27,162,56,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Camille Anne Franoise Abily,F,31,168,60,France,2016 Summer,Football,Football Women's Football,NA
+Bode Abiodun,M,35,170,68,Nigeria,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Diana Monteiro Abla,F,21,175,75,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Denis Mikhaylovich Ablyazin,M,24,161,62,Russia,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,Silver
+Denis Mikhaylovich Ablyazin,M,24,161,62,Russia,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Denis Mikhaylovich Ablyazin,M,24,161,62,Russia,2016 Summer,Gymnastics,Gymnastics Men's Horse Vault,Silver
+Denis Mikhaylovich Ablyazin,M,24,161,62,Russia,2016 Summer,Gymnastics,Gymnastics Men's Rings,Bronze
+Thorine Christelle Aboa Mbeza,F,23,182,78,Cameroon,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+"Matthew ""Matt"" Abood",M,30,197,92,Australia,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+"Matthew ""Matt"" Abood",M,30,197,92,Australia,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,Bronze
+Abdelhalim Muhammad Abou,M,27,210,88,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Ashraf Abou El-Hassan,M,41,186,86,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Mamdouh Taha Al-Husseini Abouebaid,M,28,183,85,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Alaaeldin Ahmad El-Sayyid Abouelkassem,M,25,188,87,Egypt,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Alaaeldin Ahmad El-Sayyid Abouelkassem,M,25,188,87,Egypt,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Melita Isidora Abraham Schssler,F,19,170,62,Chile,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Tadesse Abraham,M,33,178,61,Switzerland,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Yelena Vasilyevna Abramchuk (Kopets-),F,28,182,95,Belarus,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Aliyah Abrams,F,19,163,53,Guyana,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Benik Abramyan,M,31,186,115,Georgia,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Diogo Ferreira Tribolet de Abreu,M,22,183,73,Portugal,2016 Summer,Trampolining,Trampolining Men's Individual,NA
+rika Abril Surez,F,38,164,52,Colombia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+"Alejandro ""lex"" Abrines Redondo",M,23,198,93,Spain,2016 Summer,Basketball,Basketball Men's Basketball,Bronze
+Bourhan Abro,M,21,180,70,Djibouti,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Anastasiya Aleksandrovna Abrosimova,F,26,164,51,Russia,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Julien Absalon,M,35,180,68,France,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Methkal Marouf Abu Drais,M,32,168,67,Jordan,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Ahmad Abughaush,M,20,178,68,Jordan,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,Gold
+Mohammed Abukhousa,M,23,170,67,Palestine,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Kariman Abuljadayel,F,22,180,70,Saudi Arabia,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Javier Carlos Acevedo,M,18,182,68,Canada,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+Javier Carlos Acevedo,M,18,182,68,Canada,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Nicole Jocelin Acevedo Tangarife,F,21,166,70,Colombia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Sharon Evelin Acevedo Tangarife,F,23,170,61,Colombia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Jaouad Achab,M,23,175,64,Belgium,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,NA
+Karem Faride Achach Ramrez,F,25,169,60,Mexico,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Sharath Kamal Achanta,M,34,186,85,India,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Gemma Acheampong,F,23,163,54,Ghana,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Natalie Chioma Achonwa,F,23,190,86,Canada,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Chantal Achterberg,F,31,172,72,Netherlands,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,Silver
+Bryan Josu Acosta Ramos,M,22,175,74,Honduras,2016 Summer,Football,Football Men's Football,NA
+Julio Csar Acosta Gonzlez,M,29,160,62,Chile,2016 Summer,Weightlifting,Weightlifting Men's Featherweight,NA
+Marcelo Alberto Acosta Jimnez,M,20,NA,NA,El Salvador,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Marcelo Alberto Acosta Jimnez,M,20,NA,NA,El Salvador,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Marcelo Alberto Acosta Jimnez,M,20,NA,NA,El Salvador,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Mara Jos Acosta Acosta,F,24,172,69,Venezuela,2016 Summer,Wrestling,"Wrestling Women's Light-Heavyweight, Freestyle",NA
+Tanya Acosta,F,25,182,70,Argentina,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Roberto Acua,M,25,208,109,Argentina,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Arslanbek Aylow,M,23,177,75,Turkmenistan,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Seiya Adachi,M,21,172,67,Japan,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Constantin Adam,M,20,202,105,Romania,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Leonie Adam,F,23,162,54,Germany,2016 Summer,Trampolining,Trampolining Women's Individual,NA
+Antoine Xavier Adams,M,27,180,79,Saint Kitts and Nevis,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Antoine Xavier Adams,M,27,180,79,Saint Kitts and Nevis,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Antoine Xavier Adams,M,27,180,79,Saint Kitts and Nevis,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Natalie Cammile Adams (-Brannan),F,24,173,65,United States,2016 Summer,Swimming,Swimming Women's 200 metres Butterfly,NA
+Liam Adams,M,29,178,64,Australia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Mareike Adams,F,26,174,73,Germany,2016 Summer,Rowing,Rowing Women's Double Sculls,NA
+Nicola Virginia Adams,F,33,164,51,Great Britain,2016 Summer,Boxing,Boxing Women's Flyweight,Gold
+Paul Adams,M,24,185,98,Australia,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Rachael Alexis Adams,F,26,188,81,United States,2016 Summer,Volleyball,Volleyball Women's Volleyball,Bronze
+Valerie Kasanita Adams-Vili (-Price),F,31,193,120,New Zealand,2016 Summer,Athletics,Athletics Women's Shot Put,Silver
+Yasemin Adar,F,24,180,75,Turkey,2016 Summer,Wrestling,"Wrestling Women's Heavyweight, Freestyle",NA
+"Christopher Thomas ""Chris"" Adcock",M,27,183,80,Great Britain,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+"  Gabrielle Marie ""Gabby"" Adcock (White-)",F,25,167,NA,Great Britain,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+James Adede,M,29,162,92,Kenya,2016 Summer,Weightlifting,Weightlifting Men's Middle-Heavyweight,NA
+Oluwakemi 'Kemi' Adekoya,F,23,166,63,Bahrain,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Odunayo Folasade Adekuoroye,F,22,169,53,Nigeria,2016 Summer,Wrestling,"Wrestling Women's Featherweight, Freestyle",NA
+Abrar Osman Adem,M,22,168,58,Eritrea,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Biko Adema,M,28,177,85,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Aminat Oluwafunmilayo Adeniyi,F,23,165,58,Nigeria,2016 Summer,Wrestling,"Wrestling Women's Lightweight, Freestyle",NA
+Adenzia Aparecida Ferreira da Silva,F,29,187,65,Brazil,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Nyakisi Adero,F,30,NA,NA,Uganda,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Haydy Morsy Adil,F,16,168,58,Egypt,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,NA
+Adiyasambuu Tsolmon,F,23,165,65,Mongolia,2016 Summer,Judo,Judo Women's Half-Lightweight,NA
+"Bradley Don ""Brad"" Adkins",M,22,188,80,United States,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Aurimas Adomaviius,M,22,204,100,Lithuania,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Nathan Ghar-Jun Adrian,M,27,198,100,United States,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,Bronze
+Nathan Ghar-Jun Adrian,M,27,198,100,United States,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,Bronze
+Nathan Ghar-Jun Adrian,M,27,198,100,United States,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,Gold
+Nathan Ghar-Jun Adrian,M,27,198,100,United States,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,Gold
+Vera Adrian,F,22,168,57,Namibia,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+"Adriana ""Adrianinha"" Moiss Pinto",F,37,170,65,Brazil,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Erkin Adylbek uulu,M,25,190,80,Kyrgyzstan,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,NA
+Jasper Aerents,M,23,191,86,Belgium,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Jasper Aerents,M,23,191,86,Belgium,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Brian O'Neill Afanador Prez,M,19,175,68,Puerto Rico,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Khairulnizam Mohd Afendy,M,23,182,70,Malaysia,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Ahmed Afifi,M,28,194,92,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Evelina Afoa,F,17,162,60,Samoa,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Paixo Afonso,M,25,176,80,Angola,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Marina Anatolyevna Aframeyeva,F,25,171,62,Russia,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Cecil Sebastian Afrika,M,28,175,75,South Africa,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Bronze
+Khristos Afroudakis,M,32,188,88,Greece,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+"Timothy Ernest Victor Kwizera ""Tim"" Agaba",M,27,193,104,South Africa,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Bronze
+Luca Agamennoni,M,35,187,93,Italy,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Clarisse Agbegnenou,F,23,164,66,France,2016 Summer,Judo,Judo Women's Half-Middleweight,Silver
+Maia Kristiane Agerup,F,21,172,NA,Norway,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Ragna Agerup,F,21,168,NA,Norway,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Levon Aghasyan,M,21,193,75,Armenia,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Yannick Agnel,M,24,202,90,France,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Salvador Jos Milhazes Agra,M,24,168,70,Portugal,2016 Summer,Football,Football Men's Football,NA
+Renzo Pasquale Zeglio Agresta,M,31,181,76,Brazil,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Norisbeth Isais Agudo Gonzlez,F,24,163,55,Venezuela,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Alessandra Aguilar Morn,F,38,165,50,Spain,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Evelis Jazmin Aguilar Torres,F,23,173,64,Colombia,2016 Summer,Athletics,Athletics Women's Heptathlon,NA
+Felipe Aguilar Mendoza,M,23,191,72,Colombia,2016 Summer,Football,Football Men's Football,NA
+Felipe Aguilar Schler,M,41,170,72,Chile,2016 Summer,Golf,Golf Men's Individual,NA
+Iaki Aguilar Vicente,M,32,189,82,Spain,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Macarena Aguilar Daz,F,31,170,67,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+Sandra Aguilar Navarro,F,23,167,50,Spain,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,Silver
+Yulenmis Aguilar Martnez,F,20,165,66,Cuba,2016 Summer,Athletics,Athletics Women's Javelin Throw,NA
+Tomas Alonso Aguilera Armendariz,M,27,202,95,Mexico,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Carolina Aguirre Giraldo,F,20,160,59,Colombia,2016 Summer,Archery,Archery Women's Individual,NA
+Carolina Aguirre Giraldo,F,20,160,59,Colombia,2016 Summer,Archery,Archery Women's Team,NA
+rick Germain Aguirre Tafolla,M,19,170,60,Mexico,2016 Summer,Football,Football Men's Football,NA
+Gabriela Aguirre,F,30,164,58,Argentina,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Marcelo Vctor Aguirre,M,23,174,66,Paraguay,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Sri Wahyuni Agustiani,F,21,147,47,Indonesia,2016 Summer,Weightlifting,Weightlifting Women's Flyweight,Silver
+Kelsie Ahbe,F,25,170,63,Canada,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+Christian Ahlmann,M,41,189,80,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Christian Ahlmann,M,41,189,80,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",Bronze
+Tontowi Ahmad,M,29,179,72,Indonesia-1,2016 Summer,Badminton,Badminton Mixed Doubles,Gold
+Elaheh Ahmadi,F,34,160,62,Iran,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Esraa Ahmed El-Sayed,F,17,150,63,Egypt,2016 Summer,Weightlifting,Weightlifting Women's Middleweight,NA
+Ghofran Ahmed Zaki,M,23,192,68,Egypt,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,NA
+Mohammed Ahmed,M,25,182,56,Canada,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Mohammed Ahmed,M,25,182,56,Canada,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Samia Mohamed Hagrass Ahmed,F,20,170,57,Egypt,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Samia Mohamed Hagrass Ahmed,F,20,170,57,Egypt,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Masbah Ahmmed,M,21,NA,NA,Bangladesh,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Murielle Ahour,F,28,165,58,Cote d'Ivoire,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Murielle Ahour,F,28,165,58,Cote d'Ivoire,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Gaby Diana Ahrens,F,35,169,60,Namibia,2016 Summer,Shooting,Shooting Women's Trap,NA
+Mohammad Ahsan,M,28,173,72,Indonesia,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Nicole Ahsinger,F,18,163,58,United States,2016 Summer,Trampolining,Trampolining Women's Individual,NA
+Michelle-Lee Raquel Ahye,F,24,160,64,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Michelle-Lee Raquel Ahye,F,24,160,64,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Michelle-Lee Raquel Ahye,F,24,160,64,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Ai Yanhan,F,14,168,54,China,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Ai Yanhan,F,14,168,54,China,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Jrmy Aicardi,M,27,178,83,France,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Matteo Aicardi,M,30,192,102,Italy,2016 Summer,Water Polo,Water Polo Men's Water Polo,Bronze
+Vlad-Drago Aicoboae,M,22,197,91,Romania,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Neringa Aidietyt,F,33,177,60,Lithuania,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Rosaria Aiello,F,27,172,74,Italy,2016 Summer,Water Polo,Water Polo Women's Water Polo,Silver
+Hannes Aigner,M,27,183,75,Germany,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Harry Leslie Aikines-Aryeetey,M,27,180,87,Great Britain,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Sophie Claire Ainsworth,F,27,173,68,Great Britain,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Saiyidah Aisyah Mohamed Rafa'ee,F,28,173,68,Singapore,2016 Summer,Rowing,Rowing Women's Single Sculls,NA
+Rachid Ait Atmane,M,23,190,76,Algeria,2016 Summer,Football,Football Men's Football,NA
+Anasse At El Abdia,M,23,180,66,Morocco,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Zied Ait Ouagram,M,27,191,75,Morocco,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",NA
+Samir At Sad,M,26,167,65,France,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Samir At Sad,M,26,167,65,France,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Souad At Salem (-Mahour-Bacha),F,37,158,50,Algeria,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Efe Ajagba,M,22,190,NA,Nigeria,2016 Summer,Boxing,Boxing Men's Super-Heavyweight,NA
+"Oluwafemi ""Junior"" Ajayi",M,20,172,79,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Astrit Ajdarevi,M,26,190,80,Sweden,2016 Summer,Football,Football Men's Football,NA
+Mobolade Abimbola Ajomale,M,20,180,62,Canada,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Bronze
+Stella Akakpo,F,22,166,60,France,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Meryem (Mirriam Jepchirchir-) Akda (Mayo-),F,23,171,51,Turkey,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Tark Langat Akda,M,28,176,60,Turkey,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Taha Akgl,M,25,192,125,Turkey,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Freestyle",Gold
+Svitlana Viktorivna Akhadova,F,23,170,69,Ukraine,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",NA
+Habibollah Jomeh Akhlaghi,M,31,175,90,Iran,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",NA
+Murodzhon Kakharovich Akhmadaliyev,M,21,165,56,Uzbekistan,2016 Summer,Boxing,Boxing Men's Bantamweight,Bronze
+Artur Kamilevich Akhmatkhuzin,M,28,187,79,Russia,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Artur Kamilevich Akhmatkhuzin,M,28,187,79,Russia,2016 Summer,Fencing,"Fencing Men's Foil, Team",Gold
+Morolake Akinosun,F,22,163,61,United States,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,Gold
+Foluke Antinuke Akinradewo,F,28,191,79,United States,2016 Summer,Volleyball,Volleyball Women's Volleyball,Bronze
+Jonathan Akinyemi,M,27,188,85,Nigeria,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Teruyoshi Akiyama,M,44,168,65,Japan,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+Malika Al-Akkaoui,F,28,160,49,Morocco,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Malika Al-Akkaoui,F,28,160,49,Morocco,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Halil Akka,M,33,175,58,Turkey,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+"Joshua Emmanuel ""Josh"" Akognon",M,30,189,83,Nigeria,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Daniel Akpeyi,M,30,187,80,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Ahmed Akram Abbas Mahmoud,M,19,188,80,Egypt,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Ahmed Akram Abbas Mahmoud,M,19,188,80,Egypt,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Youssef Akrout,M,25,180,78,Tunisia,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Monica Aksamit,F,26,183,74,United States,2016 Summer,Fencing,"Fencing Women's Sabre, Team",Bronze
+Sonia Aktar,F,19,NA,NA,Bangladesh,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Shirin Akter,F,21,159,50,Bangladesh,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Hussein Al-Aameri,M,25,177,80,Iraq,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Ahmad Al-Afasi,M,33,NA,NA,Individual Olympic Athletes,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+Mazoon Khalfan Saleh Al-Alawi,F,18,182,NA,Oman,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Tariq Ahmed Al-Amri,M,25,165,49,Saudi Arabia,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Atallah Al-Anazi,M,28,174,74,Saudi Arabia,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Atallah Al-Anazi,M,28,174,74,Saudi Arabia,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Mary Al-Atrash,F,22,170,57,Palestine,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Nasser Salih Nasser Abdullah Al-Attiya,M,45,178,82,Qatar,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Hamad Ali Mohamed A Al-Attiyah,M,21,193,89,Qatar,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Hamad Ali Mohamed A Al-Attiyah,M,21,193,89,Qatar,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Ayesha Shahriyar Mohammed Al-Balooshi,F,24,160,57,United Arab Emirates,2016 Summer,Weightlifting,Weightlifting Women's Lightweight,NA
+Wadha Bint Nasir Al-Balushi,F,26,160,75,Oman,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Nada Mohamed Abdulzaher Mohamed Al-Bedwawi,F,18,162,53,United Arab Emirates,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Sultan Mubarak M. Al-Dawoodi,M,31,192,86,Saudi Arabia,2016 Summer,Athletics,Athletics Men's Discus Throw,NA
+Fehaid Al-Deehani,M,49,178,95,Individual Olympic Athletes,2016 Summer,Shooting,Shooting Men's Double Trap,Gold
+Mohsen Hussain Al-Duhaylib,M,22,163,69,Saudi Arabia,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Abdulrahman Al-Faihan,M,30,NA,NA,Individual Olympic Athletes,2016 Summer,Shooting,Shooting Men's Trap,NA
+Dalal Masfir Al-Harith,F,16,160,55,Qatar,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Barakat Mubarak Al-Harthi,M,28,173,67,Oman,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Khaled Al-Kaabi,M,31,168,85,United Arab Emirates,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+Obada Al-Kasbeh,M,22,166,64,Jordan,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+Mohammed Riyadh Al-Khafaji,M,22,181,75,Iraq,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Hajar Saeed Saad Sowaid Al-Khaldi,F,21,160,45,Bahrain,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Hamed Said Al-Khatri,M,31,173,68,Oman,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Noah Abdalaziz Al-Khulaifi,M,17,190,86,Qatar,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+Fatema Abdul Muhsin Al-Mahmeed,F,17,167,60,Bahrain,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Saeed bin Hasher Al-Maktoum,M,39,176,88,United Arab Emirates,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Khaled Al-Mudhaf,M,38,164,105,Individual Olympic Athletes,2016 Summer,Shooting,Shooting Men's Trap,NA
+Lubna Al-Omair,F,29,152,45,Saudi Arabia,2016 Summer,Fencing,"Fencing Women's Foil, Individual",NA
+Moukheld Mahil F. Al-Outaibi,M,40,163,60,Saudi Arabia,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Abdullah Al-Rashidi,M,52,183,83,Individual Olympic Athletes,2016 Summer,Shooting,Shooting Men's Skeet,Bronze
+Bassel Al-Rayes,M,37,180,95,Qatar,2016 Summer,Handball,Handball Men's Handball,NA
+Ali Yousef Al-Rumaihi,M,34,177,86,Qatar,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Ali Yousef Al-Rumaihi,M,34,177,86,Qatar,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Yaaqoub Al-Saadi,M,20,175,62,United Arab Emirates,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+Mayada Al-Sayad,F,23,NA,NA,Palestine,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Abdulaziz Al-Shatti,M,25,NA,NA,Individual Olympic Athletes,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Hicham Al-Siguni,M,23,172,61,Morocco,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Sheikh Ali bin Khalid Al-Thani,M,33,194,73,Qatar,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Sheikh Ali bin Khalid Al-Thani,M,33,194,73,Qatar,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Saud Al-Zaabi,M,27,NA,NA,United Arab Emirates,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Alaa Ali Mhawi,M,20,178,68,Iraq,2016 Summer,Football,Football Men's Football,NA
+Ayman Alaa El-Din Mohamed Fayez,M,25,181,72,Egypt,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Marina Alabau Neira,F,30,164,55,Spain,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Salima El Ouali Al-Alami,F,32,179,58,Morocco,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Nima Alamian,M,23,174,70,Iran,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Noshad Alamian Darounkolaei,M,24,170,67,Iran,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Julian Alaphilippe,M,24,173,62,France,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Julian Alaphilippe,M,24,173,62,France,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Ricard Alarcn Tevar,M,24,188,110,Spain,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Fernando Alarza Vicente,M,25,178,67,Spain,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Rafael Yunier Alba Castillo,M,22,202,87,Cuba,2016 Summer,Taekwondo,Taekwondo Men's Heavyweight,NA
+Matas Albarracn,M,36,174,65,Argentina,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Matas Albarracn,M,36,174,65,Argentina,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Michael Albasini,M,35,172,67,Switzerland,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Il Alben,F,30,172,62,Turkey,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Markel Alberdi Sarobe,M,24,187,76,Spain,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Fiona Albert,F,25,174,70,Australia,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Agustina Albertario,F,23,165,55,Argentina,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Nely Carla Alberto Francisca,F,33,179,90,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+Islam-Beka Said-Tsilimovich Albiyev,M,27,165,66,Russia,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Greco-Roman",NA
+Radu Albot,M,26,175,70,Moldova,2016 Summer,Tennis,Tennis Men's Singles,NA
+Samuel Albrecht,M,34,180,71,Brazil,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Gustavo Barreiros de Albuquerque,M,25,172,85,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Aurelie Alcindor,F,22,169,47,Mauritius,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Olympia Aldersey,F,24,183,75,Australia,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Mark David Aldred,M,29,188,71,Great Britain,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,NA
+David Alegre Biosca,M,31,184,75,Spain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Jo Qesem Ayela Aleh,F,30,171,58,New Zealand,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,Silver
+Eric Javier Alejandro,M,30,180,81,Puerto Rico,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Aleksandr Aleksandrov,M,26,189,93,Azerbaijan,2016 Summer,Rowing,Rowing Men's Double Sculls,NA
+Daniel Tihomirov Aleksandrov,M,24,182,81,Bulgaria,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",NA
+Artur Aleksanyan,M,24,190,98,Armenia,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Greco-Roman",Gold
+Ruben Aleksanyan,M,26,180,150,Armenia,2016 Summer,Weightlifting,Weightlifting Men's Super-Heavyweight,NA
+Yana Ivanovna Alekseevna,F,28,169,60,Azerbaijan,2016 Summer,Boxing,Boxing Women's Lightweight,NA
+Yevgeny Petrovich Alekseyev,M,38,186,93,Kazakhstan,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 1,000 metres",NA
+Milan Aleksi,M,30,193,96,Serbia,2016 Summer,Water Polo,Water Polo Men's Water Polo,Gold
+Habitam Alemu,F,19,171,52,Ethiopia,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Kineke Alicia Alexander,F,30,178,65,Saint Vincent and the Grenadines,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Alexandra Priscila do Nascimento,F,34,177,68,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Anna-Maria Alexandri,F,18,170,48,Austria,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Eirini-Marina Alexandri,F,18,171,50,Austria,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Khaido Alexouli,F,25,180,60,Greece,2016 Summer,Athletics,Athletics Women's Long Jump,NA
+Alin Alexuc-Ciurariu,M,26,191,105,Romania,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Greco-Roman",NA
+Abdoul Razak Issoufou Alfaga,M,21,207,90,Niger,2016 Summer,Taekwondo,Taekwondo Men's Heavyweight,Silver
+Natalia Alfaro Paniagua,F,29,165,59,Costa Rica,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Linda Camilla Algotsson,F,44,162,50,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Linda Camilla Algotsson,F,44,162,50,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Sara Anneli Algotsson Ostholt,F,41,163,56,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Sara Anneli Algotsson Ostholt,F,41,163,56,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Ahmed Ali,M,22,173,75,Sudan,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Kame Ali,M,32,185,84,Madagascar,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Annabel Laure Ali,F,31,176,75,Cameroon,2016 Summer,Wrestling,"Wrestling Women's Heavyweight, Freestyle",NA
+Mehboob Ali,M,26,NA,NA,Pakistan,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Muhammad Ali,M,20,173,52,Great Britain,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Nia Sifaatihii Ali,F,27,170,65,United States,2016 Summer,Athletics,Athletics Women's 100 metres Hurdles,Silver
+Ali Adnan Kadhim Nassir Al-Tameemi,M,22,185,71,Iraq,2016 Summer,Football,Football Men's Football,NA
+Ali Faez Atia,M,21,180,75,Iraq,2016 Summer,Football,Football Men's Football,NA
+Bibiro Ali Taher,F,28,160,44,Chad,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Hamza Ali,M,37,186,130,Bosnia and Herzegovina,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Zhanibek Alimkhanuly,M,23,182,75,Kazakhstan,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Aline Villares Reis,F,27,162,60,Brazil,2016 Summer,Football,Football Women's Football,NA
+Aleksey Aleksandrovich Alipov,M,40,175,80,Russia,2016 Summer,Shooting,Shooting Men's Trap,NA
+Alison Conte Cerutti,M,30,203,106,Brazil-1,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,Gold
+Pirmammad Sadiyarovich Aliyev,M,18,170,63,Kazakhstan,2016 Summer,Trampolining,Trampolining Men's Individual,NA
+Kimia Alizadeh Zenoorin,F,18,185,57,Iran,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,Bronze
+Antonio Alkana,M,26,183,76,South Africa,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Jasmine Alkhaldi,F,23,180,60,Philippines,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Fatim Alkrmova,F,14,175,60,Azerbaijan,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Claire Allan,F,31,170,65,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Florence Allan,F,18,168,57,Cayman Islands,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Heba Allejji,F,19,NA,NA,Syria,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Devon Allen,M,21,185,84,United States,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Nathon Allen,M,20,178,NA,Jamaica,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,Silver
+Daniel Allerstorfer,M,23,183,130,Austria,2016 Summer,Judo,Judo Men's Heavyweight,NA
+Laura Colleen Gloria Alleway,F,26,178,72,Australia,2016 Summer,Football,Football Women's Football,NA
+Martin Allikvee,M,21,182,77,Estonia,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Olivia Elizabeth N. Allison-Federici,F,26,169,54,Great Britain,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Andrique Allisop,M,23,171,60,Seychelles,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Jenny Alm,F,27,184,80,Sweden,2016 Summer,Handball,Handball Women's Handball,NA
+Miguel ngel Almachi Condo,M,31,165,55,Ecuador,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Rose Mary Almanza Blanco,F,24,165,53,Cuba,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Brandonn Pierry Cruz de Almeida,M,19,186,73,Brazil,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Brandonn Pierry Cruz de Almeida,M,19,186,73,Brazil,2016 Summer,Swimming,Swimming Men's 400 metres Individual Medley,NA
+Csar Augusto Oliveira de Almeida,M,27,188,98,Brazil,2016 Summer,Handball,Handball Men's Handball,NA
+Jlio Antonio de Sourza e Almeida,M,46,180,90,Brazil,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Jlio Antonio de Sourza e Almeida,M,46,180,90,Brazil,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Kaio Mrcio Ferreira Costa de Almeida,M,31,177,75,Brazil,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Luiza Tavares de Almeida,F,24,168,58,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Luiza Tavares de Almeida,F,24,168,58,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Pedro Manuel Tavares de Almeida,M,22,176,78,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Pedro Manuel Tavares de Almeida,M,22,176,78,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Teresa Patrcia Almeida,F,28,170,98,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Ives Gonzlez Alonso,M,35,191,102,Brazil,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Kirstie Elaine Alora,F,26,173,67,Philippines,2016 Summer,Taekwondo,Taekwondo Women's Heavyweight,NA
+"Mikhail Surenovich ""Misha"" Aloyan",M,27,164,52,Russia,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Mustafa Alsaltialkrad,M,29,186,90,Qatar,2016 Summer,Handball,Handball Men's Handball,NA
+Malin Therse Alshammar,F,38,180,64,Sweden,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Julio Alsogaray,M,36,180,81,Argentina,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Ida Alstad,F,31,172,60,Norway,2016 Summer,Handball,Handball Women's Handball,Bronze
+Tabea Lara Alt,F,16,158,50,Germany,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Tabea Lara Alt,F,16,158,50,Germany,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Tabea Lara Alt,F,16,158,50,Germany,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Maria Suelen Altheman,F,27,175,110,Brazil,2016 Summer,Judo,Judo Women's Heavyweight,NA
+Pavlo Serhiyovych Altukhov,M,20,185,90,Ukraine,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 1,000 metres",NA
+Alberto lvarez Muoz,M,25,191,78,Mexico,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Anita Alvarez,F,19,170,52,United States,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Eduardo lvarez Aznar,M,32,173,67,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Eduardo lvarez Aznar,M,32,173,67,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Estefana lvarez Piedrahita,F,21,162,60,Colombia,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Kevin Javier lvarez Hernndez,M,20,181,76,Honduras,2016 Summer,Football,Football Men's Football,NA
+Lzaro Jorge lvarez Estrada,M,25,173,60,Cuba,2016 Summer,Boxing,Boxing Men's Lightweight,Bronze
+Santiago lvarez Fourcade,M,22,188,93,Argentina,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Sergio lvarez Moya,M,31,174,74,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Sergio lvarez Moya,M,31,174,74,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Miguel Alvario Garca,M,22,180,84,Spain,2016 Summer,Archery,Archery Men's Individual,NA
+Miguel Alvario Garca,M,22,180,84,Spain,2016 Summer,Archery,Archery Men's Team,NA
+Yuri Alvear Orjuela,F,30,176,70,Colombia,2016 Summer,Judo,Judo Women's Middleweight,Silver
+Higor Silva Alves,M,22,183,64,Brazil,2016 Summer,Athletics,Athletics Men's Long Jump,NA
+Nariman Aly,F,17,169,55,Egypt,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Isabella del Carmen Amado Medrano,F,19,155,59,Panama,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Isabella del Carmen Amado Medrano,F,19,155,59,Panama,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Isabella del Carmen Amado Medrano,F,19,155,59,Panama,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Isabella del Carmen Amado Medrano,F,19,155,59,Panama,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Andrey Amador Bikkazakova,M,29,183,73,Costa Rica,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Mohammed Aman Geleto,M,22,165,58,Ethiopia,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Alex Amankwah,M,24,NA,NA,Ghana,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Marielle Amant,F,26,190,84,France,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Hailemariyam Amare Tegen,M,19,175,64,Ethiopia,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Yadinis Amars Rocha,F,32,162,57,Colombia,2016 Summer,Judo,Judo Women's Lightweight,NA
+Nauraj Singh Randhawa Amarjit Singh,M,24,193,70,Malaysia,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Eyawomano Doreen Amata,F,28,191,63,Nigeria,2016 Summer,Athletics,Athletics Women's High Jump,NA
+Kim Oscar Amb,M,26,180,87,Sweden,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+"William ""Willy"" Ambaka Ndayara",M,26,193,100,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Mal Ambonguilat,M,18,170,65,Gabon,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Sabrina Ameghino,F,36,169,64,Argentina,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 200 metres",NA
+Sabrina Ameghino,F,36,169,64,Argentina,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",NA
+Maha Amer,F,17,165,54,Egypt,2016 Summer,Diving,Diving Women's Springboard,NA
+Mohamed Amer,M,18,199,80,Egypt,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Mohamed Abdelraham Sayed Amer,M,28,187,87,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Christine Amertil (-Ling),F,36,168,54,Bahamas,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+David Vincent Leslie Ames,M,27,188,82,Great Britain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Audrey Amiel,F,29,164,65,France,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Sandro Aminashvili,M,24,180,85,Georgia,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Freestyle",NA
+"Abdul Wahab ""Alade"" Aminu",M,28,210,102,Nigeria,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Nina Amir,F,17,170,62,Israel,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Samira Amirova,F,18,162,47,Uzbekistan,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Savitree Amitrapai,F,27,164,56,Thailand,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+Christian Amoah,M,17,184,82,Ghana,2016 Summer,Weightlifting,Weightlifting Men's Light-Heavyweight,NA
+Andrew Amonde,M,32,190,104,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+"Eduarda Idalina ""Duda"" Amorim-Taleska",F,29,186,84,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Nijel Carlos Amilfitano Amos,M,22,179,60,Botswana,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Paulo Amotun Lokoro,M,24,170,61,Refugee Olympic Athletes,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+John Ampomah,M,26,191,100,Ghana,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+Janet Amponsah,F,23,171,52,Ghana,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Janet Amponsah,F,23,171,52,Ghana,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Marwa Al-Amri,F,27,160,58,Tunisia,2016 Summer,Wrestling,"Wrestling Women's Lightweight, Freestyle",Bronze
+Oluwatobiloba Ayomide Amusan,F,19,NA,55,Nigeria,2016 Summer,Athletics,Athletics Women's 100 metres Hurdles,NA
+Stanley Amuzie,M,20,171,85,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Hassan Amzile,M,28,183,64,France,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+An Ba-Ul,M,22,169,66,South Korea,2016 Summer,Judo,Judo Men's Half-Lightweight,Silver
+An Byeong-Hun,M,24,186,95,South Korea,2016 Summer,Golf,Golf Men's Individual,NA
+An Chang-Rim,M,22,170,73,South Korea,2016 Summer,Judo,Judo Men's Lightweight,NA
+An Hyo-Ju,F,28,168,54,South Korea,2016 Summer,Hockey,Hockey Women's Hockey,NA
+An Se-Hyeon,F,20,168,57,South Korea,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+An Se-Hyeon,F,20,168,57,South Korea,2016 Summer,Swimming,Swimming Women's 200 metres Butterfly,NA
+An Seul-Ki,F,24,161,46,South Korea,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Ana Paula Rodrigues-Belo,F,28,172,67,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Phara Anacharsis,F,32,177,58,France,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Phara Anacharsis,F,32,177,58,France,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Ioanna Anagnostopoulou,F,19,181,58,Greece,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Khrysoula Anagnostopoulou,F,24,175,85,Greece,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Yasemin Ecem Anagz,F,17,165,66,Turkey,2016 Summer,Archery,Archery Women's Individual,NA
+Lolita Volodymyrivna Ananasova,F,24,169,52,Ukraine,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Lolita Volodymyrivna Ananasova,F,24,169,52,Ukraine,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Zoya Sergeyevna Ananchenko,F,19,165,67,Kazakhstan,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 500 metres",NA
+Zoya Sergeyevna Ananchenko,F,19,165,67,Kazakhstan,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",NA
+Mikhailis Anastasakis,M,21,183,92,Greece,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+milie Andol,F,28,170,97,France,2016 Summer,Judo,Judo Women's Heavyweight,Gold
+Anne Dsane Andersen,F,23,183,86,Denmark,2016 Summer,Rowing,Rowing Women's Coxless Pairs,Bronze
+David Emil Andersen,M,36,211,102,Australia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Frida Andersn,F,26,164,67,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Frida Andersn,F,26,164,67,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Haley Danita Anderson,F,24,178,68,United States,2016 Summer,Swimming,Swimming Women's 10 kilometres Open Water,NA
+"Matthew John ""Matt"" Anderson",M,29,202,100,United States,2016 Summer,Volleyball,Volleyball Men's Volleyball,Bronze
+Jonna Andersson,F,23,167,61,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Kim Verner Andersson,M,33,200,105,Sweden,2016 Summer,Handball,Handball Men's Handball,NA
+Erik Mattias Andersson,M,38,186,95,Sweden,2016 Summer,Handball,Handball Men's Handball,NA
+Mikiko Ando,F,23,155,58,Japan,2016 Summer,Weightlifting,Weightlifting Women's Lightweight,NA
+Emanuel Alejandro Andrade Colmenares,M,19,189,76,Venezuela,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Jordin Andrade,M,24,183,77,Cape Verde,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Lady Patricia Andrade Rodrguez,F,24,172,62,Colombia,2016 Summer,Football,Football Women's Football,NA
+Maria Andrade Teixeira,F,23,169,49,Cape Verde,2016 Summer,Taekwondo,Taekwondo Women's Flyweight,NA
+Rafael Oliveira Andrade,M,30,168,58,Brazil,2016 Summer,Trampolining,Trampolining Men's Individual,NA
+Rebeca Rodrigues de Andrade,F,17,151,46,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Rebeca Rodrigues de Andrade,F,17,151,46,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Rebeca Rodrigues de Andrade,F,17,151,46,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Rebeca Rodrigues de Andrade,F,17,151,46,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Rebeca Rodrigues de Andrade,F,17,151,46,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Mathilde Andraud,F,27,173,70,France,2016 Summer,Athletics,Athletics Women's Javelin Throw,NA
+Thiago do Rosario Andr,M,20,163,52,Brazil,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Simon Andreassen,M,18,177,68,Denmark,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Maria Andrejczyk,F,20,174,77,Poland,2016 Summer,Athletics,Athletics Women's Javelin Throw,NA
+Andressa Cavalari Machry,F,21,160,60,Brazil,2016 Summer,Football,Football Women's Football,NA
+Andressa Alves da Silva,F,23,168,56,Brazil,2016 Summer,Football,Football Women's Football,NA
+"Jessica ""Jess"" Andrews (-Martin)",F,23,168,52,Great Britain,2016 Summer,Athletics,"Athletics Women's 10,000 metres",NA
+"Robert Adrian ""Robby"" Andrews",M,25,178,66,United States,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Leonid Vladimirovich Andreyev,M,32,198,93,Uzbekistan,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Sofya Denisovna Andreyeva,F,18,178,64,Russia,2016 Summer,Swimming,Swimming Women's 200 metres Breaststroke,NA
+Viktoriya Olegovna Andreyeva,F,24,190,74,Russia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Viktoriya Olegovna Andreyeva,F,24,190,74,Russia,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Viktoriya Olegovna Andreyeva,F,24,190,74,Russia,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Valeriy Oleksandrovych Andriitsev,M,29,181,97,Ukraine,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Matthieu Androdias,M,26,194,94,France,2016 Summer,Rowing,Rowing Men's Double Sculls,NA
+Vyacheslav Dmitriyevich Andrusenko,M,24,194,85,Russia,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Vyacheslav Dmitriyevich Andrusenko,M,24,194,85,Russia,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Daniel Andjar Ponce,M,22,182,78,Spain,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Youndry Andjar de la Cruz,M,26,171,60,Dominican Republic,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Dionysios Angelopoulos,M,23,189,91,Greece,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Tonje Angelsen,F,26,179,62,Norway,2016 Summer,Athletics,Athletics Women's High Jump,NA
+Rami Anis,M,25,178,78,Refugee Olympic Athletes,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Rami Anis,M,25,178,78,Refugee Olympic Athletes,2016 Summer,Swimming,Swimming Men's 100 metres Butterfly,NA
+Emilia Ankiewicz,F,25,178,64,Poland,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Ashlee Ankudinoff,F,25,174,67,Australia,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Mame-Ibra Anne,M,26,184,80,France,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Jolanda Annen,F,23,166,56,Switzerland,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Vadim Vladimirovich Anokhin,M,24,192,91,Russia,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Vadim Vladimirovich Anokhin,M,24,192,91,Russia,2016 Summer,Fencing,"Fencing Men's epee, Team",NA
+Roman Sergeyevich Anoshkin,M,28,192,95,Russia,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 1,000 metres",Bronze
+Roman Sergeyevich Anoshkin,M,28,192,95,Russia,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Chakir Ansari,M,25,168,57,Morocco,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Giselle Anne Ansley,F,24,176,73,Great Britain,2016 Summer,Hockey,Hockey Women's Hockey,Gold
+Vincent Anstett,M,34,178,78,France,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Dra Antal,F,22,169,62,Hungary,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Lissette Alexandra Antes Castillo,F,25,177,58,Ecuador,2016 Summer,Wrestling,"Wrestling Women's Lightweight, Freestyle",NA
+Carmelo Kyan Anthony,M,32,203,109,United States,2016 Summer,Basketball,Basketball Men's Basketball,Gold
+Seema Antil,F,33,182,92,India,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Franz Anton,M,26,173,70,Germany,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, Slalom",NA
+Vinicius Biagi Antonelli,M,26,183,82,Brazil,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Dimitrios Antoniadis,M,24,180,69,Greece,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Oleg Antonov,M,28,198,88,Italy,2016 Summer,Volleyball,Volleyball Men's Volleyball,Silver
+Lenka Antoov,F,24,177,70,Czech Republic,2016 Summer,Rowing,Rowing Women's Double Sculls,NA
+Mohamad Khairul Anuar,M,24,171,75,Malaysia,2016 Summer,Archery,Archery Men's Individual,NA
+Mohamad Khairul Anuar,M,24,171,75,Malaysia,2016 Summer,Archery,Archery Men's Team,NA
+Shehzana Anwar,F,26,160,55,Kenya,2016 Summer,Archery,Archery Women's Individual,NA
+Yelena Fyodorovna Anyushina,F,22,NA,NA,Russia,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 500 metres",NA
+Yelena Fyodorovna Anyushina,F,22,NA,NA,Russia,2016 Summer,Canoeing,"Canoeing Women's Kayak Doubles, 500 metres",NA
+Chika Aoki,F,26,158,54,Japan,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Tomomi Aoki,F,21,164,55,Japan,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Zouhair Aouad,M,27,175,69,Bahrain,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Eref Apak,M,34,184,120,Turkey,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Kiradech Aphibarnrat,M,27,172,104,Thailand,2016 Summer,Golf,Golf Men's Individual,NA
+Ymi Geoffrey Apithy,M,27,192,96,Benin,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Tiago Andr Barata Feio Peixoto Apolnia,M,30,185,76,Portugal,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Tiago Andr Barata Feio Peixoto Apolnia,M,30,185,76,Portugal,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Mrcio Appel,M,37,172,73,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Mrcio Appel,M,37,172,73,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Mikael Appelgren,M,26,191,103,Sweden,2016 Summer,Handball,Handball Men's Handball,NA
+Emilia Elisabeth Appelqvist,F,26,168,65,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Pablo Alejandro Aprahamian Bakerdjian,M,30,180,97,Uruguay,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Lusapho Lesly April,M,34,172,50,South Africa,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Alice Aprot Nawowuna,F,22,152,54,Kenya,2016 Summer,Athletics,"Athletics Women's 10,000 metres",NA
+Mohamed Al-Naceur Arafat,M,27,190,81,Tunisia,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Rababe Arafi,F,25,167,52,Morocco,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Rababe Arafi,F,25,167,52,Morocco,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Atsushi Arai,M,22,169,62,Japan,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Hirooki Arai,M,28,180,62,Japan,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,Bronze
+Ryohei Arai,M,25,183,96,Japan,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+Erika Araki,F,32,186,78,Japan,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Nada Mohammed Wafa S Arakji,F,21,163,59,Qatar,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+Zoe Arancini,F,25,170,70,Australia,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Mnica Sarai Arango Estrada,F,24,165,60,Colombia,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Krystian Aranowski,M,28,198,102,Poland,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+"Kalliopi ""Kelly"" Araouzou",F,25,169,55,Greece,2016 Summer,Swimming,Swimming Women's 10 kilometres Open Water,NA
+Jacob Araptany,M,22,168,58,Uganda,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Linet Arasa Moraa,F,20,173,61,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Yukiya Arashiro,M,31,171,64,Japan,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Enrique Jos Arathoon Pacas,M,24,180,78,El Salvador,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Adriana dos Santos Arajo,F,34,167,60,Brazil,2016 Summer,Boxing,Boxing Women's Lightweight,NA
+Amanda Carolina Gomes de Arajo,F,26,162,54,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Luiz Alberto Cardoso de Arajo,M,29,188,88,Brazil,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Vctor Aravena Pincheira,M,26,167,55,Chile,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Edward Ignacio Araya Corts,M,30,176,62,Chile,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Yerko Ignacio Araya Corts,M,30,178,64,Chile,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Geisa Rafaela Arcanjo,F,24,180,92,Brazil,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Katie Louise Archibald,F,22,178,70,Great Britain,2016 Summer,Cycling,Cycling Women's Team Pursuit,Gold
+Ryan Archibald,M,35,186,78,New Zealand,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Isabella Arcila Hurtado,F,22,168,64,Colombia,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Francisco Arcilla Aller,M,32,171,58,Spain,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Lus Martn Arcn Daz,M,24,179,64,Venezuela,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+Sailom Ard,M,30,172,57,Thailand,2016 Summer,Boxing,Boxing Men's Welterweight,NA
+Sandra Lorena Arenas Campuzano,F,22,160,50,Colombia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Jacco Arends,M,25,186,72,Netherlands,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+Brbara Elisabeth Arenhart,F,29,182,73,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Mareks rents,M,29,190,85,Latvia,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+ider Orlando Arvalo Truque,M,23,165,60,Colombia,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Samantha Michelle Arvalo Salinas,F,21,171,60,Ecuador,2016 Summer,Swimming,Swimming Women's 10 kilometres Open Water,NA
+Joahnys Oscar Argilagos Prez,M,19,152,49,Cuba,2016 Summer,Boxing,Boxing Men's Light-Flyweight,Bronze
+Betzabeth Anglica Argello Villegas,F,25,164,53,Venezuela,2016 Summer,Wrestling,"Wrestling Women's Featherweight, Freestyle",NA
+I Ketut Ariana,M,26,167,69,Indonesia,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Carolina Arias Vidal,F,25,159,52,Colombia,2016 Summer,Football,Football Women's Football,NA
+Kellys Yesenia Arias Figueroa,F,27,150,47,Colombia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Katherine Nataly Arias Pea,F,30,172,62,Colombia,2016 Summer,Football,Football Women's Football,NA
+Pol Arias Dourdet,M,19,175,80,Andorra,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Ferhat Arcan,M,23,178,68,Turkey,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Ferhat Arcan,M,23,178,68,Turkey,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Ferhat Arcan,M,23,178,68,Turkey,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Ferhat Arcan,M,23,178,68,Turkey,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Ferhat Arcan,M,23,178,68,Turkey,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Ferhat Arcan,M,23,178,68,Turkey,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Polat Kemboi Arkan,M,25,175,59,Turkey,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Tatiana Ariza Daz,F,25,161,52,Colombia,2016 Summer,Football,Football Women's Football,NA
+Mohamed Al-Arjaoui,M,29,185,91,Morocco,2016 Summer,Boxing,Boxing Men's Super-Heavyweight,NA
+William Peixoto Arjona,M,37,186,78,Brazil,2016 Summer,Volleyball,Volleyball Men's Volleyball,Gold
+Yuliya Vladimirovna Arkhipova-Andreyeva,F,32,168,51,Kyrgyzstan,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Alina Armas,F,32,166,53,Namibia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Jos Alexis Armenteros Surez,M,23,189,100,Cuba,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+"Elizabeth Mary ""Lizzie"" Armitstead (-Deignan)",F,27,168,55,Great Britain,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Kristin Ann Armstrong (-Savola),F,42,173,58,United States,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Kristin Ann Armstrong (-Savola),F,42,173,58,United States,2016 Summer,Cycling,Cycling Women's Individual Time Trial,Gold
+Tsanko Rosenov Arnaudov,M,24,198,155,Portugal,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Mackenzie Elizabeth Arnold,F,22,179,76,Australia,2016 Summer,Football,Football Women's Football,NA
+Marie-Cathrine Arnold,F,24,175,69,Germany,2016 Summer,Rowing,Rowing Women's Double Sculls,NA
+Emilie Hegh Arntzen,F,22,183,78,Norway,2016 Summer,Handball,Handball Women's Handball,Bronze
+Miguel da Cunha Arraiolos,M,28,173,62,Portugal,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Tania Karina Arrayales Macas,F,20,158,53,Mexico,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Tania Karina Arrayales Macas,F,20,158,53,Mexico,2016 Summer,Fencing,"Fencing Women's Sabre, Team",NA
+Andrs Arroyo,M,21,177,64,Puerto Rico,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Antonio Arroyo Prez,M,22,170,63,Spain,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Heather Ann Arseth,F,22,170,60,Mauritius,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Andreea Arsine,F,27,159,55,Romania,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Andrea Arsovi,F,29,165,61,Serbia,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Andrea Arsovi,F,29,165,61,Serbia,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Mariafe Artacho del Solar,F,22,175,66,Australia-2,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Mauricio Jos Arteaga Snchez,M,27,177,68,Ecuador,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Jenny Lyvette Arthur,F,22,166,74,United States,2016 Summer,Weightlifting,Weightlifting Women's Heavyweight,NA
+Natalia Artic-Stratulat,F,29,178,83,Moldova,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Izzat Artykov,M,22,160,69,Kyrgyzstan,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Eleni Artymata,F,30,177,62,Cyprus,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Fabio Aru,M,26,183,65,Italy,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Quadri Aruna,M,27,180,81,Nigeria,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Quadri Aruna,M,27,180,81,Nigeria,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Zorana Arunovi,F,29,168,90,Serbia,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Zorana Arunovi,F,29,168,90,Serbia,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Ardo Arusaar,M,28,181,102,Estonia,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Greco-Roman",NA
+Migran Arutyunyan,M,27,166,67,Armenia,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Greco-Roman",Silver
+Gremlis Andrena Arvelo Garca,F,19,167,62,Venezuela,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Marina Aleksandrovna Arzamasova (Katovich-),F,28,173,58,Belarus,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Mohammad Arzandeh,M,28,180,77,Iran,2016 Summer,Athletics,Athletics Men's Long Jump,NA
+Man Asaad,M,22,190,143,Syria,2016 Summer,Weightlifting,Weightlifting Men's Super-Heavyweight,NA
+Laura Asadauskait-Zadneprovskien,F,32,160,49,Lithuania,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,NA
+Sakiyo Asano,F,29,164,60,Japan,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Takuma Asano,M,21,171,67,Japan,2016 Summer,Football,Football Men's Football,NA
+Dmitry Sergeyevich Asanov,M,20,176,56,Belarus,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Nataliya Asanova,F,26,177,58,Uzbekistan,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Pyotr Petrovich Asayonok,M,23,165,85,Belarus,2016 Summer,Weightlifting,Weightlifting Men's Light-Heavyweight,NA
+Santiago Ascacibar,M,19,168,69,Argentina,2016 Summer,Football,Football Men's Football,NA
+Raheleh Asemani,F,27,171,59,Belgium,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,NA
+Sabina Asenjo lvarez,F,30,178,90,Spain,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Daniel Asenov,M,19,163,52,Bulgaria,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Ronnie Ash,M,28,188,95,United States,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Bradlee Logan Taylor Ashby,M,20,200,92,New Zealand,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Bradlee Logan Taylor Ashby,M,20,200,92,New Zealand,2016 Summer,Swimming,Swimming Men's 200 metres Individual Medley,NA
+Andrey Viktorovich Ashchev,M,33,202,105,Russia,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+"Geraldina Rachel ""Dina"" Asher-Smith",F,20,164,55,Great Britain,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+"Geraldina Rachel ""Dina"" Asher-Smith",F,20,164,55,Great Britain,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,Bronze
+Qais Dad Ashfaq,M,23,170,56,Great Britain,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Sabina Ashirbayeva,F,17,163,45,Kazakhstan,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Individual,NA
+Whitney Jordan Ashley,F,27,178,91,United States,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Nickel Ashmeade,M,26,183,77,Jamaica,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Nickel Ashmeade,M,26,183,77,Jamaica,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Nickel Ashmeade,M,26,183,77,Jamaica,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Gold
+Aditi Ashok,F,18,173,57,India,2016 Summer,Golf,Golf Women's Individual,NA
+Farzan Ashour Zadeh Fllah,M,19,185,58,Iran,2016 Summer,Taekwondo,Taekwondo Men's Flyweight,NA
+Jessica Ashwood,F,23,173,64,Australia,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Jessica Ashwood,F,23,173,64,Australia,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,NA
+Jessica Ashwood,F,23,173,64,Australia,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,Silver
+"Kosovare ""Kosse"" Asllani",F,27,166,56,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Sofia Asoumanaki,F,19,190,85,Greece,2016 Summer,Rowing,Rowing Women's Double Sculls,NA
+Rustam Skhatbiyevich Assakalov,M,32,183,85,Uzbekistan,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",NA
+Jeanine Assani Issouf,F,23,170,53,France,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+Khalid Assar,M,23,198,99,Egypt,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Omar Muhammadi Muhammad Muhammad Assar,M,25,196,93,Egypt,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Sofia Assefa Abebe,F,28,167,52,Ethiopia,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Tigist Assefa,F,19,168,53,Ethiopia,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Sonia Asselah,F,24,176,78,Algeria,2016 Summer,Judo,Judo Women's Heavyweight,NA
+Anton Viktorovich Astakhov,M,29,176,85,Russia,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Gloria Asumnu,F,31,168,64,Nigeria,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Gloria Asumnu,F,31,168,64,Nigeria,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Merdan Ataew,M,21,196,80,Turkmenistan,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+Sarah Atcho,F,21,180,63,Switzerland,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Soule Soilihi Athoumane,M,25,180,75,Comoros,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Ron Atias,M,21,170,58,Israel,2016 Summer,Taekwondo,Taekwondo Men's Flyweight,NA
+Teddy H. Atine-Venel,M,31,184,77,France,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Alia Shanee Atkinson,F,27,172,71,Jamaica,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Mert Atl,M,23,191,70,Turkey,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Sleyman Atl,M,22,168,57,Turkey,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Sarah Amer Attar,F,23,165,52,Saudi Arabia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Ahmad Mohamed Attellesey,M,21,NA,NA,Libya,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Manu Attri,M,23,172,73,India,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Amjad Attwan Kadhim,M,19,180,72,Iraq,2016 Summer,Football,Football Men's Football,NA
+"Hoi Shun ""Stephanie"" Au",F,24,172,56,Hong Kong,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Felix Aubck,M,19,198,85,Austria,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Felix Aubck,M,19,198,85,Austria,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Felix Aubck,M,19,198,85,Austria,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Sandra Auffarth,F,29,170,57,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Sandra Auffarth,F,29,170,57,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",Silver
+Benjamin Auffret,M,21,166,54,France,2016 Summer,Diving,Diving Men's Platform,NA
+Laura Marie Aug,F,24,175,60,France,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Haley Ruth Augello,F,21,157,54,United States,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Jordan Augier,M,21,171,53,Saint Lucia,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Axel Louis Augis,M,25,172,71,France,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Marlon August-Accio,M,34,180,81,Mozambique,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+"Dionisio Augustine, II",M,24,153,65,Federated States of Micronesia,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Jssica de Barros Augusto,F,34,162,44,Portugal,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Seimone Delicia Augustus,F,32,183,74,United States,2016 Summer,Basketball,Basketball Women's Basketball,Gold
+Rafa Augustyn,M,32,180,82,Poland,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Bastien Auzeil,M,26,195,89,France,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Aram Avagyan,M,25,173,56,Armenia,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Henrique Avancini,M,27,176,67,Brazil,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+"Nazeli ""Nazik"" Avdalyan",F,29,157,69,Armenia,2016 Summer,Weightlifting,Weightlifting Women's Light-Heavyweight,NA
+Anton Alekseyevich Avdeyev,M,29,174,85,Russia,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Anton Alekseyevich Avdeyev,M,29,174,85,Russia,2016 Summer,Fencing,"Fencing Men's epee, Team",NA
+Maksim Averin,M,30,189,75,Azerbaijan,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Ceiber David vila Segura,M,27,162,49,Colombia,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Giorgio Avola,M,27,178,72,Italy,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Giorgio Avola,M,27,178,72,Italy,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Ekaterina Ivanova Avramova,F,24,180,68,Turkey,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,NA
+Mohd Azizulhasni Awang,M,28,166,69,Malaysia,2016 Summer,Cycling,Cycling Men's Keirin,Bronze
+Viktor Axelsen,M,22,194,88,Denmark,2016 Summer,Badminton,Badminton Men's Singles,Bronze
+Derlis Ramn Ayala Snchez,M,26,178,75,Paraguay,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Julin Ayala Navarrete,M,24,171,80,Mexico,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Hiwot Ayalew Yeder,F,26,173,53,Ethiopia,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Almaz Ayana Eba,F,24,166,47,Ethiopia,2016 Summer,Athletics,"Athletics Women's 5,000 metres",Bronze
+Almaz Ayana Eba,F,24,166,47,Ethiopia,2016 Summer,Athletics,"Athletics Women's 10,000 metres",Gold
+Hela Al-Ayari,F,21,NA,52,Tunisia,2016 Summer,Judo,Judo Women's Half-Lightweight,NA
+Valriane Ayayi,F,22,184,72,France,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Ventsislav Vasilev Aydarski,M,25,168,60,Bulgaria,2016 Summer,Swimming,Swimming Men's 10 kilometres Open Water,NA
+Esma Aydemir,F,24,160,48,Turkey,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Diana Aydosova,F,20,158,50,Kazakhstan,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Camille Anas Ayglon-Saurina,F,31,180,66,France,2016 Summer,Handball,Handball Women's Handball,Silver
+Miranda Joy Ayim,F,28,190,72,Canada,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Akossiwa Claire Ayivon,F,19,NA,NA,Togo,2016 Summer,Rowing,Rowing Women's Single Sculls,NA
+Duygu Aynac,F,20,170,69,Turkey,2016 Summer,Weightlifting,Weightlifting Women's Light-Heavyweight,NA
+Oscar Ayodi,M,26,184,94,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Ned Justeen Azemia,M,18,177,65,Seychelles,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Ctia Isabel da Silva Azevedo,F,22,170,50,Portugal,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+"Anthony Lawrence ""Tony"" Azevedo",M,34,186,90,United States,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Yasmina Aziez,F,25,172,52,France,2016 Summer,Taekwondo,Taekwondo Women's Flyweight,NA
+Ahmad Amsyar Azman,M,23,162,62,Malaysia,2016 Summer,Diving,Diving Men's Springboard,NA
+Jrmie Azou,M,27,178,71,France,2016 Summer,Rowing,Rowing Men's Lightweight Double Sculls,Gold
+Okechukwu Godson Azubuike,M,19,170,68,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Houleye Ba,F,24,170,55,Mauritania,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Nooran Ahmed Ali Ba Matraf,F,16,166,60,Yemen,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+"Alexander German ""Sander"" Baart",M,28,178,76,Netherlands,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Baatarskhiin Chinzorig,M,24,174,64,Mongolia,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+Jaroslav Bba,M,31,199,86,Czech Republic,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Bashir Asgari Babajanzadeh Darzi,M,26,188,130,Iran,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Greco-Roman",NA
+Glbadam Babamyradowa,F,24,156,52,Turkmenistan,2016 Summer,Judo,Judo Women's Half-Lightweight,NA
+Lalita Shivaji Babar,F,27,166,50,India,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Hrachik Babayan,M,20,175,75,Armenia,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Nazim Tahir olu Babayev,M,18,187,74,Azerbaijan,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Luka Babi,M,24,202,94,Croatia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Brian Babilonia,M,21,180,66,Puerto Rico,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Kumari Babita,F,26,165,52,India,2016 Summer,Wrestling,"Wrestling Women's Featherweight, Freestyle",NA
+Tmea Babos,F,23,179,68,Hungary,2016 Summer,Tennis,Tennis Women's Singles,NA
+Tmea Babos,F,23,179,68,Hungary,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Marta Bach Pascual,F,23,176,66,Spain,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+"Adrian ""Adri"" Delgado Baches",M,26,184,83,Brazil,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Hovhannes Bachkov,M,23,173,64,Armenia,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+Diana Bacosi,F,33,175,85,Italy,2016 Summer,Shooting,Shooting Women's Skeet,Gold
+Pter Bcsi,M,33,175,82,Hungary,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",NA
+Timea Bacsinszky,F,27,170,62,Switzerland,2016 Summer,Tennis,Tennis Women's Singles,NA
+Timea Bacsinszky,F,27,170,62,Switzerland,2016 Summer,Tennis,Tennis Women's Doubles,Silver
+Imre Balzs Bacskai,M,28,177,72,Hungary,2016 Summer,Boxing,Boxing Men's Welterweight,NA
+Mohamed Badawy,M,30,195,91,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Joel Baden,M,20,190,70,Australia,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Ahmed Bader Magour,M,20,190,90,Qatar,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+Bae Yeon-Ju,F,25,167,57,South Korea,2016 Summer,Badminton,Badminton Women's Singles,NA
+Bae Yoo-Na,F,26,182,66,South Korea,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Baek Ee-Seul,F,21,175,72,South Korea,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Baek Su-Yeon,F,25,173,61,South Korea,2016 Summer,Swimming,Swimming Women's 200 metres Breaststroke,NA
+Marta Baenza Centurion,F,24,164,52,Brazil,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Marko Bagari,M,30,201,100,Qatar,2016 Summer,Handball,Handball Men's Handball,NA
+Jos Alessandro Bernardo Baggio,M,35,172,63,Brazil,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Prviz Barov,M,22,177,69,Azerbaijan,2016 Summer,Boxing,Boxing Men's Welterweight,NA
+Julien Bahain,M,30,190,93,Canada,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Viviane Kretzmann Bahia,F,22,176,67,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Meraf Bahta Ogbagaber,F,27,176,52,Sweden,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Bai Faquan,M,30,173,66,China,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Daniel Everton Bailey,M,29,179,68,Antigua and Barbuda,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Nathan Stephen C. Bailey,M,23,178,71,Great Britain,2016 Summer,Trampolining,Trampolining Men's Individual,NA
+Tavis Bailey,M,24,191,125,United States,2016 Summer,Athletics,Athletics Men's Discus Throw,NA
+Kemar Bailey-Cole,M,24,193,84,Jamaica,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Gold
+Ryan Bailie,M,26,177,61,Australia,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Cameron David Bairstow,M,25,206,118,Australia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Balzs Baji,M,27,192,85,Hungary,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Bak Ji-Yun,F,23,168,63,South Korea,2016 Summer,Judo,Judo Women's Half-Middleweight,NA
+Brian Richard Baker,M,31,191,77,United States,2016 Summer,Tennis,Tennis Men's Singles,NA
+Brian Richard Baker,M,31,191,77,United States-1,2016 Summer,Tennis,Tennis Men's Doubles,NA
+"Christopher Edwin ""Chris"" Baker",M,25,194,80,Great Britain,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Georgia Baker,F,21,179,66,Australia,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Kathleen Baker,F,19,173,68,United States,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,Silver
+Kathleen Baker,F,19,173,68,United States,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,Gold
+Mashu Baker,M,21,178,90,Japan,2016 Summer,Judo,Judo Men's Middleweight,Gold
+Perry Baker,M,30,185,82,United States,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Shakira Baker,F,24,172,89,New Zealand,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Silver
+Amina Barsham Bakhit,F,25,175,59,Sudan,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Mohammad Tawfiq Bakhshi,M,30,181,99,Afghanistan,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Abdullah Hel Baki,M,27,170,82,Bangladesh,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Naima Bakkal,F,25,170,57,Morocco,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,NA
+Billy Pierre Bakker,M,27,188,82,Netherlands,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Hosam Bakr Hosam Abdin,M,30,178,69,Egypt,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Konstantin Anatolyevich Bakun,M,31,204,96,Russia,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Nina Balaban,F,20,158,58,Macedonia,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Dmitry Igorevich Balandin,M,21,195,85,Kazakhstan,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Dmitry Igorevich Balandin,M,21,195,85,Kazakhstan,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,Gold
+Deivy Alexander Balanta Abona,M,23,180,77,Colombia,2016 Summer,Football,Football Men's Football,NA
+Kevin Alexander Balanta Licum,M,19,179,73,Colombia,2016 Summer,Football,Football Men's Football,NA
+Boris Bal,M,18,182,72,Slovakia,2016 Summer,Archery,Archery Men's Individual,NA
+Barbora Balov,F,24,169,73,Slovakia,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Egl Balinait,F,27,176,63,Lithuania,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Tais Balconi,F,25,164,63,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Elisabeth Baldauf,F,26,175,62,Austria,2016 Summer,Badminton,Badminton Women's Singles,NA
+Laurence Baldauff,F,41,164,57,Austria,2016 Summer,Archery,Archery Women's Individual,NA
+"Carlos Zenon Balderas, Jr.",M,19,175,60,United States,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Andrea Baldini,M,30,175,70,Italy,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Hugo Balduino de Sousa,M,29,187,74,Brazil,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Birhanu Yemataw Balew,M,20,NA,NA,Bahrain,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Onur Balkan,M,20,176,70,Turkey,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Maret Balkestein-Grothues,F,27,180,68,Netherlands,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Coralie Balmy,F,29,180,67,France,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Coralie Balmy,F,29,180,67,France,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Coralie Balmy,F,29,180,67,France,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Michal Balner,M,33,191,80,Czech Republic,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Gbor Balog,M,25,186,80,Hungary,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+Gbor Balog,M,25,186,80,Hungary,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Bernardo Baloyes Navas,M,22,168,66,Colombia,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Ksenija Balta,F,29,169,51,Estonia,2016 Summer,Athletics,Athletics Women's Long Jump,NA
+Margaret Bamgbose,F,22,171,63,Nigeria,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Abdoullah Bamoussa,M,30,170,59,Italy,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Andreia Bandeira,F,29,169,75,Brazil,2016 Summer,Boxing,Boxing Women's Middleweight,NA
+Haris Bandey,M,17,167,79,Pakistan,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Allan Alexander Banegas Murillo,M,22,180,76,Honduras,2016 Summer,Football,Football Men's Football,NA
+Mamadama Bangoura,F,22,176,63,Guinea,2016 Summer,Judo,Judo Women's Half-Middleweight,NA
+"Konstantinos ""Kostas"" Baniotis",M,29,201,80,Greece,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Blair Cameron Bann,M,28,184,84,Canada,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Amine Bannour,M,26,196,102,Tunisia,2016 Summer,Handball,Handball Men's Handball,NA
+Heather Bansley,F,28,170,66,Canada-1,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Sarah Banting,F,22,165,60,Australia,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Kayla Banwarth,F,27,178,70,United States,2016 Summer,Volleyball,Volleyball Women's Volleyball,Bronze
+Ivan Mykolaiyovych Banzeruk,M,26,180,70,Ukraine,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Bao Yuqing,F,22,173,55,China,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Kelly-Ann Kaylene Baptiste,F,29,167,54,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Kelly-Ann Kaylene Baptiste,F,29,167,54,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Khader Ghetrich Baqlah,M,17,184,80,Jordan,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Talita Baqlah,F,20,172,62,Jordan,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Elsa Mara Baquerizo McMillan,F,29,181,68,Spain,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Carina Br,F,26,185,75,Germany,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,Gold
+Jorge Alejandro Barajas Gonzlez,M,25,188,80,Mexico,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Radosaw Baran,M,26,177,97,Poland,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Robert Baran,M,24,186,103,Poland,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Freestyle",NA
+"Matthew ""Matt"" Baranoski",M,23,183,96,United States,2016 Summer,Cycling,Cycling Men's Keirin,NA
+"Katarzyna ""Kasia"" Baranowska",F,28,184,72,Poland,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Zbigniew Mateusz Baranowski,M,25,180,86,Poland,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Freestyle",NA
+Mohammad Reza Barari,M,28,180,85,Iran,2016 Summer,Weightlifting,Weightlifting Men's Heavyweight,NA
+"Akalaini ""Bui"" Baravilala",F,25,168,75,United States,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Filipe Baravilala,M,21,170,74,Fiji,2016 Summer,Football,Football Men's Football,NA
+Azad Al-Barazi,M,28,195,85,Syria,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Ana Luiza Busato Barbachan,F,26,171,68,Brazil,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Anthony John Barbar,M,23,201,100,Lebanon,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Brbara Seixas de Freitas,F,29,178,67,Brazil-1,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,Silver
+Brbara Micheline do Monte Barbosa,F,28,171,71,Brazil,2016 Summer,Football,Football Women's Football,NA
+Alana Barber,F,29,163,52,New Zealand,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+"Shawnacy Campbell ""Shawn"" Barber",M,22,187,82,Canada,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Jade Fernandes Barbosa,F,25,151,45,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Jade Fernandes Barbosa,F,25,151,45,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Jade Fernandes Barbosa,F,25,151,45,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Jade Fernandes Barbosa,F,25,151,45,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Jade Fernandes Barbosa,F,25,151,45,Brazil,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Leandro Mateus Barbosa,M,33,194,97,Brazil,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Neyde Marisa Pina Barbosa,F,35,175,87,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Vera Lcia Mendes Barbosa,F,27,168,58,Portugal,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Stephan de Freitas Barcha,M,26,NA,NA,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Stephan de Freitas Barcha,M,26,NA,NA,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Virginia Bardach Martn,F,24,174,57,Argentina,2016 Summer,Swimming,Swimming Women's 200 metres Butterfly,NA
+Virginia Bardach Martn,F,24,174,57,Argentina,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Virginia Bardach Martn,F,24,174,57,Argentina,2016 Summer,Swimming,Swimming Women's 400 metres Individual Medley,NA
+Romain Bardet,M,25,184,64,France,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Giovanni Battista Bardis,M,29,177,85,France,2016 Summer,Weightlifting,Weightlifting Men's Light-Heavyweight,NA
+Warren Barguil,M,24,184,62,France,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Antonino Barill,M,28,187,96,Italy,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+Sonja Barjaktarovi,F,29,180,74,Montenegro,2016 Summer,Handball,Handball Women's Handball,NA
+Elinor Jane Barker,F,21,168,56,Great Britain,2016 Summer,Cycling,Cycling Women's Team Pursuit,Gold
+Roxanne Kimberly Barker,F,25,178,76,South Africa,2016 Summer,Football,Football Women's Football,NA
+Emre Zafer (Winston-) Barnes,M,27,178,73,Turkey,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Harrison Bryce Jordan Barnes,M,24,203,102,United States,2016 Summer,Basketball,Basketball Men's Basketball,Gold
+"Patrick Gerard ""Paddy"" Barnes",M,29,163,49,Ireland,2016 Summer,Boxing,Boxing Men's Light-Flyweight,NA
+Tarasue Barnett,F,22,178,81,Jamaica,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+McQuin Baron,M,20,206,104,United States,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Thomas Gabriel Jrmie Baroukh,M,28,183,70,France,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,Bronze
+Thomas Barr,M,24,183,73,Ireland,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Bronte Amelia Arnold Barratt,F,27,171,59,Australia,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Bronte Amelia Arnold Barratt,F,27,171,59,Australia,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,Silver
+Danny Barrett,M,26,188,102,United States,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Hugo Barrette,M,25,175,90,Canada,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Francisco Carlos Barretto Jnior,M,26,175,72,Brazil,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+"Jennifer Mae ""Jenny"" Barringer-Simpson",F,29,166,53,United States,2016 Summer,Athletics,"Athletics Women's 1,500 metres",Bronze
+Mara Noel Barrionuevo,F,32,171,58,Argentina,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Pablo Jos Barrios Linares,M,52,178,72,Venezuela,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Wilmar Enrique Barrios Tern,M,22,179,70,Colombia,2016 Summer,Football,Football Men's Football,NA
+Erick Bernab Barrondo Garca,M,25,178,60,Guatemala,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Sarah Ellen Barrow,F,27,162,52,Great Britain,2016 Summer,Diving,Diving Women's Platform,NA
+Thomas Barrows III,M,28,186,82,United States,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Esther Barrugus Alvina,F,36,164,60,Andorra,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Steeve Barry,M,25,181,85,France,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Trevor George Barry,M,33,190,77,Bahamas,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Florina Maria Brsan-Chintoan,F,30,178,67,Romania,2016 Summer,Handball,Handball Women's Handball,NA
+Mutaz Essa Barshim,M,25,190,65,Qatar,2016 Summer,Athletics,Athletics Men's High Jump,Silver
+Dmitry Nikolayevich Barsuk,M,36,193,86,Russia-2,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Tatyana Valeryevna Barsuk,F,31,170,66,Russia,2016 Summer,Shooting,Shooting Women's Trap,NA
+Jacob Jepsen Barse,M,27,188,73,Denmark,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,Silver
+Adrien Bart,M,24,185,84,France,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 1,000 metres",NA
+Jan Brta,M,31,184,75,Czech Republic,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Jan Brta,M,31,184,75,Czech Republic,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Danka Bartekov,F,31,170,55,Slovakia,2016 Summer,Shooting,Shooting Women's Skeet,NA
+Beatrice Bartelloni,F,23,165,50,Italy,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+"Christopher Roger ""Chris"" Bartley",M,32,178,72,Great Britain,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,NA
+Saskia Bartusiak,F,33,170,60,Germany,2016 Summer,Football,Football Women's Football,Gold
+Morea Baru,M,26,162,62,Papua New Guinea,2016 Summer,Weightlifting,Weightlifting Men's Featherweight,NA
+Malin Birgitta Baryard-Johnsson,F,41,172,52,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Malin Birgitta Baryard-Johnsson,F,41,172,52,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Anastasiya Vladimirovna Baryshnikova,F,25,173,67,Russia,2016 Summer,Taekwondo,Taekwondo Women's Welterweight,NA
+Dimitri David Bascou,M,29,181,80,France,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,Bronze
+Ghulam Mustafa Bashir,M,29,180,74,Pakistan,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+Mirza Bai,M,25,188,87,Bosnia and Herzegovina,2016 Summer,Tennis,Tennis Men's Singles,NA
+Nikoloz Basilashvili,M,24,185,80,Georgia,2016 Summer,Tennis,Tennis Men's Singles,NA
+Fabio Basile,M,21,160,66,Italy,2016 Summer,Judo,Judo Men's Half-Lightweight,Gold
+Kudakwashe Basopo,F,26,162,60,Zimbabwe,2016 Summer,Football,Football Women's Football,NA
+Gina Bass,F,21,NA,NA,Gambia,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Ray Bassil,F,27,175,65,Lebanon,2016 Summer,Shooting,Shooting Women's Trap,NA
+Imad Bassou,M,23,173,66,Morocco,2016 Summer,Judo,Judo Men's Half-Lightweight,NA
+Bat-Ochiryn Ser-Od,M,34,169,61,Mongolia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Polona Batagelj,F,27,173,53,Slovenia,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Adam Batirov,M,31,165,71,Bahrain,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Freestyle",NA
+Paulo Roberto Batista Jnior,M,23,185,90,Brazil,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Noemi Batki,F,28,167,62,Italy,2016 Summer,Diving,Diving Women's Platform,NA
+Manika Batra,F,21,179,63,India,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Batsaikhanyn Dlgn,M,29,179,72,Mongolia,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Vitalina Igorevna Batsarashkina,F,19,162,60,Russia,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",Silver
+Vitalina Igorevna Batsarashkina,F,19,162,60,Russia,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Romano Battisti,M,29,190,91,Italy,2016 Summer,Rowing,Rowing Men's Double Sculls,NA
+Battulgyn Temlen,M,27,183,124,Mongolia,2016 Summer,Judo,Judo Men's Heavyweight,NA
+Emily Batty,F,28,161,48,Canada,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Nicolas Batum,M,27,203,105,France,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Martin Bau,M,21,182,74,Slovenia,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Mathieu Albert Daniel Bauderlique,M,27,185,81,France,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,Bronze
+Robert Bauer,M,21,183,76,Germany,2016 Summer,Football,Football Men's Football,Silver
+Grgory Benot Baug,M,31,181,100,France,2016 Summer,Cycling,Cycling Men's Sprint,NA
+Grgory Benot Baug,M,31,181,100,France,2016 Summer,Cycling,Cycling Men's Team Sprint,Bronze
+Ashton Baumann,M,23,191,74,Canada,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Christian Baumann,M,21,163,60,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Christian Baumann,M,21,163,60,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Christian Baumann,M,21,163,60,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Christian Baumann,M,21,163,60,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Christian Baumann,M,21,163,60,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Jackie Baumann,F,20,173,58,Germany,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Anne Sofie Holm Baumeister (Jrgensen-),F,28,168,54,Denmark,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Iga Baumgart,F,27,178,58,Poland,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Simona Baumrtov,F,24,176,68,Czech Republic,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Simona Baumrtov,F,24,176,68,Czech Republic,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,NA
+Simona Baumrtov,F,24,176,68,Czech Republic,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Simona Baumrtov,F,24,176,68,Czech Republic,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Roberto Bautista Agut,M,28,183,76,Spain,2016 Summer,Tennis,Tennis Men's Singles,NA
+Roberto Bautista Agut,M,28,183,76,Spain-1,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Louise Bawden,F,34,183,72,Australia-1,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Ana Gabriela Bayardo Chan,F,22,168,73,Mexico,2016 Summer,Archery,Archery Women's Individual,NA
+Ana Gabriela Bayardo Chan,F,22,168,73,Mexico,2016 Summer,Archery,Archery Women's Team,NA
+Bayartsogtyn Mnkhzayaa,F,22,160,43,Mongolia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Bayaryn Yosi,F,16,176,61,Mongolia,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Aron John Baynes,M,29,208,115,Australia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Martha Bayona Pineda,F,20,155,60,Colombia,2016 Summer,Cycling,Cycling Women's Keirin,NA
+zge Bayrak,F,24,166,60,Turkey,2016 Summer,Badminton,Badminton Women's Singles,NA
+Rvn Bayramov,M,29,160,59,Azerbaijan,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Greco-Roman",NA
+Nikolay Nikolaev Bayryakov,M,26,180,89,Bulgaria,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",NA
+Hamdan Iqbal Ahmed Bayusuf,M,21,182,64,Kenya,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+Sandro Bazadze,M,23,193,88,Georgia,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Nadezhda Valeryevna Bazhina,F,28,170,59,Russia,2016 Summer,Diving,Diving Women's Springboard,NA
+Lorne Dorcas Bazolo,F,33,170,60,Portugal,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Lorne Dorcas Bazolo,F,33,170,60,Portugal,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Gemma Beadsworth,F,29,180,78,Australia,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Daniel Beale,M,23,184,74,Australia,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Beatriz Zaneratto Joo,F,22,176,69,Brazil,2016 Summer,Football,Football Women's Football,NA
+Marie-ve Beauchemin-Nadeau,F,27,166,69,Canada,2016 Summer,Weightlifting,Weightlifting Women's Light-Heavyweight,NA
+Catherine Beauchemin-Pinard,F,22,161,57,Canada,2016 Summer,Judo,Judo Women's Lightweight,NA
+Cassandre Beaugrand,F,19,177,54,France,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Jack Robert A. Beaumont,M,22,188,88,Great Britain,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Maxime Eugne Ren Beaumont,M,34,191,94,France,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",Silver
+Maxime Eugne Ren Beaumont,M,34,191,94,France,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+"Joshua ""Josh"" Beaver",M,23,175,70,Australia,2016 Summer,Swimming,Swimming Men's 100 metres Backstroke,NA
+"Joshua ""Josh"" Beaver",M,23,175,70,Australia,2016 Summer,Swimming,Swimming Men's 200 metres Backstroke,NA
+Annika Beck,F,22,170,59,Germany,2016 Summer,Tennis,Tennis Women's Singles,NA
+Laetitia Beck,F,24,175,61,Israel,2016 Summer,Golf,Golf Women's Individual,NA
+Leonie Antonia Beck,F,19,184,62,Germany,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,NA
+Nicole Elise Beck,F,28,168,66,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Gold
+Charlotte Becker,F,33,173,64,Germany,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Janine Elizabeth Beckie,F,21,173,63,Canada,2016 Summer,Football,Football Women's Football,Bronze
+Kierre Beckles,F,26,169,54,Barbados,2016 Summer,Athletics,Athletics Women's 100 metres Hurdles,NA
+Jana Beckmann,F,33,170,60,Germany,2016 Summer,Shooting,Shooting Women's Trap,NA
+Alex Beddoes,M,21,181,74,Cook Islands,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Domonic Bedggood,M,21,163,64,Australia,2016 Summer,Diving,Diving Men's Platform,NA
+gatha Bednarczuk Rippel,F,33,182,70,Brazil-1,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,Silver
+Sylwester Bednarek,M,27,194,78,Poland,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Bartosz Bednorz,M,22,201,84,Poland,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Olivier Beer,M,25,180,69,Switzerland,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",NA
+Ludger Beerbaum,M,52,190,85,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Ludger Beerbaum,M,52,190,85,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",Bronze
+Irina Camelia Begu,F,25,181,67,Romania,2016 Summer,Tennis,Tennis Women's Singles,NA
+Irina Camelia Begu,F,25,181,67,Romania,2016 Summer,Tennis,Tennis Mixed Doubles,NA
+Irina Camelia Begu,F,25,181,67,Romania-1,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Kieran Philip Behan,M,27,163,65,Ireland,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Kieran Philip Behan,M,27,163,65,Ireland,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Kieran Philip Behan,M,27,163,65,Ireland,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Kieran Philip Behan,M,27,163,65,Ireland,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Kieran Philip Behan,M,27,163,65,Ireland,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Kieran Philip Behan,M,27,163,65,Ireland,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+"Genevieve ""Gen"" Behrent",F,25,183,73,New Zealand,2016 Summer,Rowing,Rowing Women's Coxless Pairs,Silver
+"Genevieve ""Gen"" Behrent",F,25,183,73,New Zealand,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Melanie Behringer,F,30,172,71,Germany,2016 Summer,Football,Football Women's Football,Gold
+Milad Beigi Hareqani,M,25,197,80,Azerbaijan,2016 Summer,Taekwondo,Taekwondo Men's Welterweight,Bronze
+Elizabeth Lyon Beisel,F,23,168,68,United States,2016 Summer,Swimming,Swimming Women's 400 metres Individual Medley,NA
+Ruth Beita Vila,F,37,191,72,Spain,2016 Summer,Athletics,Athletics Women's High Jump,Gold
+Sofia Bekatorou (-Kosmatopoulos),F,38,172,62,Greece,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Alemu Bekele Gebre,M,26,162,59,Bahrain,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Maryna Oleksandrivna Bekh,F,21,174,62,Ukraine,2016 Summer,Athletics,Athletics Women's Long Jump,NA
+Annemiek Bekkering,F,24,160,54,Netherlands,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Katia Belabbas,F,20,170,65,Algeria,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Teja Belak,F,22,157,48,Slovenia,2016 Summer,Gymnastics,Gymnastics Women's Horse Vault,NA
+Jose Blanger,F,30,163,63,Canada,2016 Summer,Football,Football Women's Football,Bronze
+Yekaterina Vladimirovna Belanovich (Artyukh-),F,24,173,64,Belarus,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Valentin Belaud,M,23,181,73,France,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Lani Belcher,F,27,169,65,Great Britain,2016 Summer,Canoeing,"Canoeing Women's Kayak Doubles, 500 metres",NA
+Mathew Belcher,M,33,173,62,Australia,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,Silver
+Claudia Renate Belderbos,F,31,175,72,Netherlands,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Gianina Elena Beleag,F,21,178,57,Romania,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Zhan Vensanovych Beleniuk,M,25,178,85,Ukraine,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",Silver
+Mimi Belete Gebregeiorges,F,28,169,56,Bahrain,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Yehualeye Beletew,F,18,165,52,Ethiopia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Mohammed El-Amine Belferar,M,25,175,65,Algeria,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Choaib Belhaj Salah,M,29,194,86,Tunisia,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Yvon Belin,F,22,188,74,Netherlands,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Maria Belimpasaki,F,25,175,64,Greece,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Julia Beljajeva,F,24,176,70,Estonia,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Julia Beljajeva,F,24,176,70,Estonia,2016 Summer,Fencing,"Fencing Women's epee, Team",NA
+Haris Belkebla,M,22,178,70,Algeria,2016 Summer,Football,Football Men's Football,NA
+Jonathan Bell,M,29,178,77,Ireland,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Tia-Adana Belle,F,20,178,59,Barbados,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Janeil Bellille,F,27,163,59,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Thomaz Cocchiarali Bellucci,M,28,187,80,Brazil,2016 Summer,Tennis,Tennis Men's Singles,NA
+Thomaz Cocchiarali Bellucci,M,28,187,80,Brazil-1,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Dailn Belmonte Torres,F,30,158,52,Cuba,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Mireia Belmonte Garca,F,25,170,59,Spain,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Mireia Belmonte Garca,F,25,170,59,Spain,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,NA
+Mireia Belmonte Garca,F,25,170,59,Spain,2016 Summer,Swimming,Swimming Women's 200 metres Butterfly,Gold
+Mireia Belmonte Garca,F,25,170,59,Spain,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Mireia Belmonte Garca,F,25,170,59,Spain,2016 Summer,Swimming,Swimming Women's 400 metres Individual Medley,Bronze
+Wilhem Belocian,M,21,178,78,France,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Yana Borysivna Belomoina,F,23,164,46,Ukraine,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Alexander Belonogoff,M,26,187,90,Australia,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,Silver
+Mara Amelia Belotti,F,27,180,73,Argentina,2016 Summer,Handball,Handball Women's Handball,NA
+Marco Belotti,M,27,185,76,Italy,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Marco Belotti,M,27,185,76,Italy,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Olga Konstantinovna Belova-Gorbunova,F,22,169,60,Russia,2016 Summer,Water Polo,Water Polo Women's Water Polo,Bronze
+Anastasiya Yevgenyevna Belyakova,F,23,173,60,Russia,2016 Summer,Boxing,Boxing Women's Lightweight,Bronze
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,Silver
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,Bronze
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+David Sagitovich Belyavsky,M,24,165,55,Russia,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Rahma Ben Ali,F,22,159,55,Tunisia,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,NA
+Karem Ben Hnia,M,21,165,69,Tunisia,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Afef Ben Ismail,F,22,173,60,Tunisia,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 500 metres",NA
+Meziane Ben Tahar,M,22,168,62,Algeria,2016 Summer,Football,Football Men's Football,NA
+Amor Ben Yahia,M,31,175,63,Tunisia,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Tarek Aziz Benaissa,M,25,170,66,Algeria,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Greco-Roman",NA
+Abderrahmane Benamadi,M,31,183,90,Algeria,2016 Summer,Judo,Judo Men's Middleweight,NA
+"Christopher Anthony ""Chris"" Benard",M,26,191,84,United States,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Alfonso Benavides Lpez de Ayala,M,25,182,86,Spain,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 200 metres",NA
+Jhow Hendric Benavdez Banegas,M,20,179,76,Honduras,2016 Summer,Football,Football Men's Football,NA
+Reda Benbaziz,M,22,175,60,Algeria,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Abdelhafid Benchabla,M,29,184,81,Algeria,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,NA
+Sofiane Bendebka,M,23,170,65,Algeria,2016 Summer,Football,Football Men's Football,NA
+Garrett Bender,M,24,193,105,United States,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Lars Bender,M,27,184,80,Germany,2016 Summer,Football,Football Men's Football,Silver
+Sven Bender,M,27,185,80,Germany,2016 Summer,Football,Football Men's Football,Silver
+Giordano Benedetti,M,27,189,67,Italy,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Michele Benedetti,M,31,175,68,Italy,2016 Summer,Diving,Diving Men's Springboard,NA
+Meaghan Benfeito,F,27,155,48,Canada,2016 Summer,Diving,Diving Women's Platform,Bronze
+Meaghan Benfeito,F,27,155,48,Canada,2016 Summer,Diving,Diving Women's Synchronized Platform,Bronze
+Angelica Therese Bengtsson,F,23,163,52,Sweden,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+Rolf-Gran Bengtsson,M,54,171,67,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Rolf-Gran Bengtsson,M,54,171,67,Sweden,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Abdelraouf Benguit,M,20,170,65,Algeria,2016 Summer,Football,Football Men's Football,NA
+Vtor Alves Benite,M,26,190,88,Brazil,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Alejandra Jhonay de Jess Bentez Romero,F,36,169,62,Venezuela,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Mohammed Benkablia,M,23,180,72,Algeria,2016 Summer,Football,Football Men's Football,NA
+Mohamed Benkhemassa,M,23,175,60,Algeria,2016 Summer,Football,Football Men's Football,NA
+"Brittany ""Britt"" Benn",F,27,165,68,Canada,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Bronze
+"Christopher ""Chris"" Bennett",M,26,188,115,Great Britain,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+George Bennett,M,26,181,58,New Zealand,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Karen Bennett,F,27,179,75,Great Britain,2016 Summer,Rowing,Rowing Women's Coxed Eights,Silver
+Mark Stewart Bennett,M,23,183,89,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Silver
+Paul Bennett,M,27,207,100,Great Britain,2016 Summer,Rowing,Rowing Men's Coxed Eights,Gold
+Craig Harry Benson,M,22,183,80,Great Britain,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Gordon James Benson,M,22,191,78,Great Britain,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Jake Bensted,M,22,173,73,Australia,2016 Summer,Judo,Judo Men's Lightweight,NA
+"Joseph ""Gunnar"" Bentz",M,20,196,84,United States,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,Gold
+Matej Beu,M,28,196,83,Slovakia,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",Silver
+Jan Benzien,M,34,180,75,Germany,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, Slalom",NA
+Ji Beran,M,34,192,80,Czech Republic,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Riardas Berankis,M,26,175,70,Lithuania,2016 Summer,Tennis,Tennis Men's Singles,NA
+Ccilia Berder,F,26,171,65,France,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Ccilia Berder,F,26,171,65,France,2016 Summer,Fencing,"Fencing Women's Sabre, Team",NA
+Zsombor Berecz,M,30,195,95,Hungary,2016 Summer,Sailing,Sailing Men's One Person Heavyweight Dinghy,NA
+Mdlina Bere,F,23,186,75,Romania,2016 Summer,Rowing,Rowing Women's Coxless Pairs,NA
+Mdlina Bere,F,23,186,75,Romania,2016 Summer,Rowing,Rowing Women's Coxed Eights,Bronze
+Katarna Bereov,F,28,162,49,Slovakia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Jana Berezko-Marggrander,F,20,165,44,Germany,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Individual,NA
+Kristoffer Zakarias Berg,M,21,181,86,Sweden,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",NA
+Stig Andr Berge,M,33,167,60,Norway,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Greco-Roman",Bronze
+Emma Sofia Berglund,F,27,171,64,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Arthur Bomfim Bergo,M,22,183,83,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Fredrik Bergstrm,M,26,176,64,Sweden,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Lemi Berhanu Hayle,M,21,168,53,Ethiopia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Boris Berian,M,23,183,70,United States,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Levan Berianidze,M,25,186,125,Armenia,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Freestyle",NA
+Valmir Berisha,M,20,182,81,Sweden,2016 Summer,Football,Football Men's Football,NA
+Patricia Alejandra Bermdez,F,29,150,48,Argentina,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Mara Bernabu Avomo,F,28,170,70,Spain,2016 Summer,Judo,Judo Women's Middleweight,NA
+Maria Bernard,F,23,165,53,Canada,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Natlia Maria Bernardo,F,29,170,65,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Soa Bernardov,F,40,167,54,Czech Republic,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Jean-Baptiste Bernaz,M,29,190,80,France,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Pter Bernek,M,24,193,83,Hungary,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Pter Bernek,M,24,193,83,Hungary,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Pter Bernek,M,24,193,83,Hungary,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Juozas Bernotas,M,27,186,80,Lithuania,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+Gwen Berry,F,27,175,89,United States,2016 Summer,Athletics,Athletics Women's Hammer Throw,NA
+Aleksandr Nikolayevich Bersanov,M,23,176,94,Belarus,2016 Summer,Weightlifting,Weightlifting Men's Middle-Heavyweight,NA
+Elena Berta,F,24,171,58,Italy,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Nino Daniele Bertasio,M,28,183,88,Italy,2016 Summer,Golf,Golf Men's Individual,NA
+Liam Bertazzo,M,24,185,70,Italy,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",NA
+Kiki Bertens,F,24,182,69,Netherlands,2016 Summer,Tennis,Tennis Women's Singles,NA
+Kiki Bertens,F,24,182,69,Netherlands,2016 Summer,Tennis,Tennis Mixed Doubles,NA
+Laurie Berthon,F,24,169,69,France,2016 Summer,Cycling,Cycling Women's Omnium,NA
+"Kathleen ""Kate"" Bertko",F,32,175,58,United States,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Sara Bertolasi,F,28,179,68,Italy,2016 Summer,Rowing,Rowing Women's Coxless Pairs,NA
+Veronica Bertolini,F,20,167,48,Italy,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Individual,NA
+Catherine Bertone,F,44,160,45,Italy,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Azza Besbes,F,25,175,62,Tunisia,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Sarra Besbes,F,27,175,62,Tunisia,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Anas Beshr,M,23,NA,NA,Egypt,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Jules Yao Bessan,M,37,183,85,Benin,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Billy Besson,M,35,169,69,France,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Jahvid Andre Best,M,27,178,90,Saint Lucia,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Otar Omarovich Bestayev,M,24,160,60,Kyrgyzstan,2016 Summer,Judo,Judo Men's Extra-Lightweight,NA
+Claudia Alejandra Betancur Suescun,F,29,160,82,Colombia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Berta Betanzos Moro,F,28,179,71,Spain,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Bruno Bethlem de Amorim,M,40,181,72,Brazil,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Nicholas Kiplagat Bett,M,26,190,75,Kenya,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Amina Bettiche,F,28,165,55,Algeria,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Nicole Beukers,F,25,170,66,Netherlands,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,Silver
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Brinn John Bevan,M,19,165,62,Great Britain,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Kelsey Bevan,F,26,174,70,New Zealand,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Allison Beveridge,F,23,169,62,Canada,2016 Summer,Cycling,Cycling Women's Team Pursuit,Bronze
+Allison Beveridge,F,23,169,62,Canada,2016 Summer,Cycling,Cycling Women's Omnium,NA
+Chala Beyo Techo,M,20,176,58,Ethiopia,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Marko Bezjak,M,30,184,87,Slovenia,2016 Summer,Handball,Handball Men's Handball,NA
+Eleanor Bezzina,F,39,154,NA,Malta,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Eleanor Bezzina,F,39,154,NA,Malta,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Luke Bezzina,M,21,NA,NA,Malta,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Nenad Beik,M,27,202,96,Serbia,2016 Summer,Rowing,Rowing Men's Coxless Pairs,NA
+Mohamed Ali Bhar,M,26,180,82,Tunisia,2016 Summer,Handball,Handball Men's Handball,NA
+Saraswati Bhattarai,F,22,163,46,Nepal,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Dattu Baban Bhokanal,M,25,189,81,India,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Bi Shengfeng,M,27,183,87,China,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Freestyle",NA
+Bian Ka,F,23,182,115,China,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Ilaria Bianchi,F,26,170,65,Italy,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+Ilaria Bianchi,F,26,170,65,Italy,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Valeria Bianchi,F,30,170,62,Argentina,2016 Summer,Handball,Handball Women's Handball,NA
+Ilaria Bianco,F,36,165,55,Italy,2016 Summer,Fencing,"Fencing Women's Sabre, Team",NA
+Roberta Bianconi,F,27,176,76,Italy,2016 Summer,Water Polo,Water Polo Women's Water Polo,Silver
+Magorzata Biaecka,F,28,164,54,Poland,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+"Daniel ""Dan"" Bibby",M,25,176,86,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Silver
+Olha Anatolivna Bibik,F,26,178,64,Ukraine,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Olha Anatolivna Bibik,F,26,178,64,Ukraine,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Yuliya Valentinovna Bichik,F,33,184,84,Belarus,2016 Summer,Rowing,Rowing Women's Double Sculls,NA
+Walid Bidani,M,22,185,125,Algeria,2016 Summer,Weightlifting,Weightlifting Men's Super-Heavyweight,NA
+Paul Biedermann,M,29,193,93,Germany,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Paul Biedermann,M,29,193,93,Germany,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Yiech Pur Biel,M,21,178,62,Refugee Olympic Athletes,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Karol Bielecki,M,34,202,106,Poland,2016 Summer,Handball,Handball Men's Handball,NA
+Mateusz Bieniek,M,22,210,98,Poland,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Fiona Clare Bigwood,F,40,173,75,Great Britain,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Fiona Clare Bigwood,F,40,173,75,Great Britain,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",Silver
+Marko Bija,M,25,201,85,Croatia,2016 Summer,Water Polo,Water Polo Men's Water Polo,Silver
+Miro Bilan,M,27,213,121,Croatia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Simone Arianne Biles,F,19,143,47,United States,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,Gold
+Simone Arianne Biles,F,19,143,47,United States,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,Gold
+Simone Arianne Biles,F,19,143,47,United States,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,Gold
+Simone Arianne Biles,F,19,143,47,United States,2016 Summer,Gymnastics,Gymnastics Women's Horse Vault,Gold
+Simone Arianne Biles,F,19,143,47,United States,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Simone Arianne Biles,F,19,143,47,United States,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,Bronze
+Simonas Bilis,M,22,196,84,Lithuania,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Simonas Bilis,M,22,196,84,Lithuania,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Simonas Bilis,M,22,196,84,Lithuania,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Cindy Billaud,F,30,167,59,France,2016 Summer,Athletics,Athletics Women's 100 metres Hurdles,NA
+"Gregory ""Greg"" Billington",M,27,175,66,United States,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Lauren Billys,F,28,161,59,Puerto Rico,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Mathieu Bilodeau,M,32,185,74,Canada,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+"Ricardo ""Bimba"" Winicki Santos",M,36,185,73,Brazil,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+Saif Bin Futtais,M,42,174,90,United Arab Emirates,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Abhinav Bindra,M,33,173,70,India,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Wilfried Bingangoye,M,31,172,80,Gabon,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Khamica Bingham,F,22,160,61,Canada,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Khamica Bingham,F,22,160,61,Canada,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+"Joshua ""Josh"" Binstock",M,35,196,99,Canada-2,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Emanuele Birarelli,M,35,202,95,Italy,2016 Summer,Volleyball,Volleyball Men's Volleyball,Silver
+Stefan Birevi,M,26,210,104,Serbia,2016 Summer,Basketball,Basketball Men's Basketball,Silver
+Stephen Bird,M,28,189,86,Australia,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+"Suzanne Brigit ""Sue"" Bird",F,35,175,66,United States,2016 Summer,Basketball,Basketball Women's Basketball,Gold
+Dane Alex Bird-Smith,M,24,187,72,Australia,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,Bronze
+Onur Cavit Biriz,M,17,186,73,Turkey,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+Damien Birkinhead,M,23,190,140,Australia,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Vera Leonidovna Biryukova,F,18,168,47,Russia,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,Gold
+Ketija Birzule,F,17,164,60,Latvia,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Pauline Biscarat,F,27,157,53,France,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+"Andrew Thomas ""Andy"" Bisek",M,29,178,82,United States,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",NA
+Isobel Bishop,F,24,180,72,Australia,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Melissa Corrine Bishop,F,27,173,56,Canada,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Mateusz Biskup,M,22,190,91,Poland,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Vittorio Bissaro,M,29,183,72,Italy,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Brenden Bissett,M,23,178,73,Canada,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Stanley Kipleting Biwott,M,30,152,61,Kenya,2016 Summer,Athletics,Athletics Men's Marathon,NA
+"Movladdin ""Arthur"" Biyarslanov",M,21,174,64,Canada,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+Christine Louise Bjerendal,F,29,161,59,Sweden,2016 Summer,Archery,Archery Women's Individual,NA
+Susann Jakobsen Bjrnsen,F,23,182,72,Norway,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Susann Jakobsen Bjrnsen,F,23,182,72,Norway,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Jakob Blbjerg Mathiasen,M,21,185,78,Denmark,2016 Summer,Football,Football Men's Football,NA
+"Elsabeth ""Ellie"" Black",F,20,155,56,Canada,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+"Elsabeth ""Ellie"" Black",F,20,155,56,Canada,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+"Elsabeth ""Ellie"" Black",F,20,155,56,Canada,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+"Elsabeth ""Ellie"" Black",F,20,155,56,Canada,2016 Summer,Gymnastics,Gymnastics Women's Horse Vault,NA
+"Elsabeth ""Ellie"" Black",F,20,155,56,Canada,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+"Elsabeth ""Ellie"" Black",F,20,155,56,Canada,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Blake Blackburn,M,24,181,82,Australia,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Emma Stina Blackstenius,F,20,173,69,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Alicia Jane Blagg,F,19,167,60,Great Britain,2016 Summer,Diving,Diving Women's Synchronized Springboard,NA
+Bla Blagotinek,M,22,202,108,Slovenia,2016 Summer,Handball,Handball Men's Handball,NA
+Constantin Blaha,M,28,178,76,Austria,2016 Summer,Diving,Diving Men's Springboard,NA
+Yohan Blake,M,26,180,80,Jamaica,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Yohan Blake,M,26,180,80,Jamaica,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Yohan Blake,M,26,180,80,Jamaica,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Gold
+Leandro Yamil Blanc,M,23,156,49,Argentina,2016 Summer,Boxing,Boxing Men's Light-Flyweight,NA
+Joaqun Blanco Albalat,M,27,181,80,Spain,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Jay Michael Blankenau,M,26,194,94,Canada,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+"Benjamin Floyd ""Ben"" Blankenship",M,27,178,64,United States,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Romain Blary,M,30,195,100,France,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Jessica Blaszka,F,23,160,52,Netherlands,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Marko Blaevski,M,23,183,73,Macedonia,2016 Summer,Swimming,Swimming Men's 200 metres Individual Medley,NA
+Holly Bethan Bleasdale-Bradshaw,F,24,175,67,Great Britain,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+Keston Bledman,M,28,180,88,Trinidad and Tobago,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Keston Bledman,M,28,180,88,Trinidad and Tobago,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Irina Valeryevna Bliznova,F,29,182,68,Russia,2016 Summer,Handball,Handball Women's Handball,Gold
+Anastasiya Ilyinichna Bliznyuk,F,22,173,51,Russia,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,Gold
+Shani Bloch (-Davidov),F,37,162,59,Israel,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Jason Block,M,26,182,82,Canada,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Jason Block,M,26,182,82,Canada,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Linn Blohm,F,24,180,79,Sweden,2016 Summer,Handball,Handball Women's Handball,NA
+Merel Blom,F,29,171,60,Netherlands,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Merel Blom,F,29,171,60,Netherlands,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Hanna Blomstrand,F,19,173,72,Sweden,2016 Summer,Handball,Handball Women's Handball,NA
+Artem Oleksiyovych Bloshenko,M,31,187,100,Ukraine,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Olga Yevgenyevna Bludova-Safronova,F,24,171,62,Kazakhstan,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Olga Yevgenyevna Bludova-Safronova,F,24,171,62,Kazakhstan,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Olga Yevgenyevna Bludova-Safronova,F,24,171,62,Kazakhstan,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Daniel Bluman Doron,M,26,182,72,Colombia,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Pernille Blume,F,22,170,58,Denmark,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,Gold
+Pernille Blume,F,22,170,58,Denmark,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Pernille Blume,F,22,170,58,Denmark,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Pernille Blume,F,22,170,58,Denmark,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,Bronze
+Kristian Blummenfeldt,M,22,177,NA,Norway,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+"Jennifer ""Jenny"" Blundell",F,22,163,49,Australia,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Madonna Blyth,F,30,165,60,Australia,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Adrian Bocki,M,26,174,62,Poland,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Anna Boada Peir,F,23,165,60,Spain,2016 Summer,Rowing,Rowing Women's Coxless Pairs,NA
+Elyane Eullia Alfama Duarte Freire de Andrade Boal,F,18,170,58,Cape Verde,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Individual,NA
+Ernesto Horacio Boardman Lpez,M,23,175,92,Mexico,2016 Summer,Archery,Archery Men's Individual,NA
+Lucilla Boari,F,19,162,82,Italy,2016 Summer,Archery,Archery Women's Individual,NA
+Lucilla Boari,F,19,162,82,Italy,2016 Summer,Archery,Archery Women's Team,NA
+Claudia Mihaela Bobocea,F,24,176,53,Romania,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Ancua Bobocel,F,28,167,49,Romania,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Jack Bobridge,M,27,180,65,Australia,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",Silver
+Vladlena Eduardovna Bobrovnikova,F,28,180,72,Russia,2016 Summer,Handball,Handball Women's Handball,Gold
+Gauthier Boccard,M,24,186,79,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+Federico Bocchia,M,29,197,93,Italy,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Annika Bochmann,F,25,167,58,Germany,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Solomon Bockarie-Bayoh,M,29,171,72,Netherlands,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Solomon Bockarie-Bayoh,M,29,171,72,Netherlands,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Solomon Bockarie-Bayoh,M,29,171,72,Netherlands,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Markus Bckermann,M,30,192,95,Germany,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Gbor Gyula Boczk,M,39,192,89,Hungary,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Gbor Gyula Boczk,M,39,192,89,Hungary,2016 Summer,Fencing,"Fencing Men's epee, Team",Bronze
+Michal Alexandre Bodegas,M,29,192,102,Italy,2016 Summer,Water Polo,Water Polo Men's Water Polo,Bronze
+Lauren Boden-Wells,F,28,178,66,Australia,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Maciej Bodnar,M,31,186,78,Poland,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Maciej Bodnar,M,31,186,78,Poland,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Madeleine Samantha Bodo Essissima,F,24,182,75,Cameroon,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Ihor Valeriyovych Bodrov,M,29,184,77,Ukraine,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Mathias Boe,M,36,185,75,Denmark,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Melissa Boekelman,F,27,176,87,Netherlands,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Sylwia Katarzyna Bogacka,F,34,162,57,Poland,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Sylwia Katarzyna Bogacka,F,34,162,57,Poland,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Bogdan Bogdanovi,M,23,197,99,Serbia,2016 Summer,Basketball,Basketball Men's Basketball,Silver
+Bojan Bogdanovi,M,27,200,103,Croatia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Tijana Bogdanovi,F,18,172,52,Serbia,2016 Summer,Taekwondo,Taekwondo Women's Flyweight,Silver
+Anastasia Katerina Bogdanovski,F,23,174,57,Macedonia,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Andreea Boghian,F,24,186,78,Romania,2016 Summer,Rowing,Rowing Women's Coxed Eights,Bronze
+Andrew Michael Bogut,M,31,213,122,Australia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Georgia Bohl,F,19,167,54,Australia,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Georgia Bohl,F,19,167,54,Australia,2016 Summer,Swimming,Swimming Women's 200 metres Breaststroke,NA
+Richrd Bohus,M,23,187,81,Hungary,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Richrd Bohus,M,23,187,81,Hungary,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Richrd Bohus,M,23,187,81,Hungary,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Aauri Lorena Bokesa Abia,F,27,180,62,Spain,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Peter Bol,M,22,177,63,Australia,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Linda Bolder,F,28,173,70,Israel,2016 Summer,Judo,Judo Women's Middleweight,NA
+Cynthia Maduengele Bolingo Mbongo,F,23,165,53,Belgium,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Shmagi Bolkvadze,M,22,170,66,Georgia,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Greco-Roman",Bronze
+Timo Boll,M,35,181,74,Germany,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Timo Boll,M,35,181,74,Germany,2016 Summer,Table Tennis,Table Tennis Men's Team,Bronze
+Usain St. Leo Bolt,M,29,196,95,Jamaica,2016 Summer,Athletics,Athletics Men's 100 metres,Gold
+Usain St. Leo Bolt,M,29,196,95,Jamaica,2016 Summer,Athletics,Athletics Men's 200 metres,Gold
+Usain St. Leo Bolt,M,29,196,95,Jamaica,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Gold
+Anzor Adamovich Boltukayev,M,30,180,97,Russia,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+brahim Blkba,M,25,187,97,Turkey,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Dean Bomba,M,27,189,94,Slovenia,2016 Summer,Handball,Handball Men's Handball,NA
+Thiago Bomfim Campos Dantas,M,25,193,84,Brazil,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Henning Bommel,M,33,183,79,Germany,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",NA
+Bret Bonanni,M,22,194,92,United States,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Berta Bonastre Peremateu,F,24,157,50,Spain,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Alistair Bond,M,26,186,71,New Zealand,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,NA
+Hamish Byron Bond,M,30,189,89,New Zealand,2016 Summer,Rowing,Rowing Men's Coxless Pairs,Gold
+Artyom Yuryevich Bondarenko,M,25,187,78,Belarus,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Bohdan Viktorovych Bondarenko,M,26,198,77,Ukraine,2016 Summer,Athletics,Athletics Men's High Jump,Bronze
+Yaroslava Aleksandrovna Bondarenko,F,19,158,62,Russia,2016 Summer,Cycling,Cycling Women's BMX,NA
+Roman Romanovych Bondaruk,M,42,178,95,Ukraine,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+Edwina Claire Bone,F,28,170,70,Australia,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Antoaneta Nikolaeva Boneva,F,30,168,70,Bulgaria,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Antoaneta Nikolaeva Boneva,F,30,168,70,Bulgaria,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Liemarvin Bonevacia,M,27,185,74,Netherlands,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Liemarvin Bonevacia,M,27,185,74,Netherlands,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Caio Oliveira de Sena Bonfim,M,25,174,60,Brazil,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Caio Oliveira de Sena Bonfim,M,25,174,60,Brazil,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Celma da Graa Soares Bonfim,F,38,165,58,Sao Tome and Principe,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Cristian Harson Bonilla Garzn,M,23,188,85,Colombia,2016 Summer,Football,Football Men's Football,NA
+Magaly Bonilla Sols,F,24,152,54,Ecuador,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Charlotte Bonin,F,29,173,60,Italy,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Bartomiej Wojciech Bonk,M,31,181,105,Poland,2016 Summer,Weightlifting,Weightlifting Men's Heavyweight,NA
+Daisurami Bonne Rousseau,F,28,171,60,Cuba,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Yowlys Bonne Rodrguez,M,32,152,57,Cuba,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Charlotte Bonnet,F,21,175,64,France,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Charlotte Bonnet,F,21,175,64,France,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Charlotte Bonnet,F,21,175,64,France,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Charlotte Bonnet,F,21,175,64,France,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Charlotte Bonnet,F,21,175,64,France,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Brent Bookwalter,M,32,181,68,United States,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Brent Bookwalter,M,32,181,68,United States,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Tom Boon,M,26,184,81,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+"Joshua ""Josh"" Booth",M,25,190,93,Australia,2016 Summer,Rowing,Rowing Men's Coxless Fours,Silver
+Rohan Bopanna,M,36,190,87,India,2016 Summer,Tennis,Tennis Mixed Doubles,NA
+Rohan Bopanna,M,36,190,87,India,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Barna Bor,M,29,191,130,Hungary,2016 Summer,Judo,Judo Men's Heavyweight,NA
+Hillary Bor,M,26,168,52,United States,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Kjetil Borch,M,26,193,84,Norway,2016 Summer,Rowing,Rowing Men's Double Sculls,Bronze
+Giorgia Bordignon,F,29,161,63,Italy,2016 Summer,Weightlifting,Weightlifting Women's Middleweight,NA
+Yannick Philippe Andr Borel,M,27,197,100,France,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Yannick Philippe Andr Borel,M,27,197,100,France,2016 Summer,Fencing,"Fencing Men's epee, Team",Gold
+Cleopatra Ayesha Borel-Brown,F,37,172,89,Trinidad and Tobago,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Fernando Borello,M,36,188,92,Argentina,2016 Summer,Shooting,Shooting Men's Trap,NA
+Pavel Gennadyevich Boreysha,M,25,193,120,Belarus,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Karla Borger,F,27,180,68,Germany-2,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Felipe Borges da Silva,M,21,185,72,Brazil,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",NA
+Gabriel Borges,M,24,180,73,Brazil,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Luisa Nunes Porto Borges,F,20,166,54,Brazil,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Luisa Nunes Porto Borges,F,20,166,54,Brazil,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Matheus Borges Ferreira,M,23,176,78,Brazil,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Maurcio Borges Almeida Silva,M,27,199,99,Brazil,2016 Summer,Volleyball,Volleyball Men's Volleyball,Gold
+Michel de Souza Borges,M,25,182,81,Brazil,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,NA
+Konstantin Igorevich Borichevsky,M,26,191,87,Belarus,2016 Summer,Athletics,Athletics Men's Long Jump,NA
+Mariya Olegovna Borisova,F,19,184,95,Russia,2016 Summer,Water Polo,Water Polo Women's Water Polo,Bronze
+Cristian Alexis Borja Gonzalz,M,23,179,72,Colombia,2016 Summer,Football,Football Men's Football,NA
+Miguel ngel Borja Hernndez,M,23,182,74,Colombia,2016 Summer,Football,Football Men's Football,NA
+Dylan Borle,M,23,190,78,Belgium,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Jonathan Borle,M,28,180,69,Belgium,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Jonathan Borle,M,28,180,69,Belgium,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Jonathan Borle,M,28,180,69,Belgium,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Kvin Borle,M,28,180,67,Belgium,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Kvin Borle,M,28,180,67,Belgium,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Olivia Borle,F,30,172,57,Belgium,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Brittany Borman,F,27,183,77,United States,2016 Summer,Athletics,Athletics Women's Javelin Throw,NA
+Jevgijs Borodavko,M,29,190,100,Latvia,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Ismael Borrero Molina,M,24,160,59,Cuba,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Greco-Roman",Gold
+Ian Borrows,M,26,186,78,Australia,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",NA
+Peer Borsky,M,25,192,80,Switzerland,2016 Summer,Fencing,"Fencing Men's epee, Team",NA
+Theo Bos,M,32,190,85,Netherlands,2016 Summer,Cycling,Cycling Men's Sprint,NA
+Theo Bos,M,32,190,85,Netherlands,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Theo Bos,M,32,190,85,Netherlands,2016 Summer,Cycling,Cycling Men's Team Sprint,NA
+Willemijn Bos,F,28,181,69,Netherlands,2016 Summer,Hockey,Hockey Women's Hockey,Silver
+Leticia Boscacci,F,30,186,70,Argentina,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Dylan Bosch,M,23,178,75,South Africa,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Dylan Bosch,M,23,178,75,South Africa,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Tijana Bokovi,F,19,193,82,Serbia,2016 Summer,Volleyball,Volleyball Women's Volleyball,Silver
+Vanessa Boslak,F,34,170,57,France,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+Pierre-Ambroise Bosse,M,24,185,68,France,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Roger-Yves Bost,M,50,176,80,France,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Roger-Yves Bost,M,50,176,80,France,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",Gold
+Teona Bostashvili,F,18,159,48,Georgia,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+"Thomas Stewart ""Tom"" Bosworth",M,26,178,54,Great Britain,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Jhonnatan Botero Villegas,M,24,167,58,Colombia,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Diego Botn Sanz de Sautuola Le Chever,M,22,183,81,Spain,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Christine Botlogetswe,F,20,170,65,Botswana,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Joachim Bottieau,M,27,180,81,Belgium,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Chafik Bouaoud,M,17,177,74,Algeria,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Ins Boubakri,F,27,167,56,Tunisia,2016 Summer,Fencing,"Fencing Women's Foil, Individual",Bronze
+Antoine Bouchard,M,21,180,66,Canada,2016 Summer,Judo,Judo Men's Half-Lightweight,NA
+Dominique Bouchard,F,25,175,61,Canada,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Dominique Bouchard,F,25,175,61,Canada,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,NA
+Eugenie Bouchard,F,22,178,58,Canada,2016 Summer,Tennis,Tennis Women's Singles,NA
+Eugenie Bouchard,F,22,178,58,Canada,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Landre Bouchard,M,23,193,81,Canada,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Maxim Bouchard,M,25,174,71,Canada,2016 Summer,Diving,Diving Men's Platform,NA
+Hugo Boucheron,M,23,195,90,France,2016 Summer,Rowing,Rowing Men's Double Sculls,NA
+Hicham Bouchicha,M,27,182,64,Algeria,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Thomas Boudat,M,22,175,69,France,2016 Summer,Cycling,Cycling Men's Omnium,NA
+Amel Bouderra,F,27,163,NA,France,2016 Summer,Basketball,Basketball Women's Basketball,NA
+David Alasdair Boudia,M,27,175,73,United States,2016 Summer,Diving,Diving Men's Platform,Bronze
+David Alasdair Boudia,M,27,175,73,United States,2016 Summer,Diving,Diving Men's Synchronized Platform,Silver
+Saoussen Boudiaf,F,22,173,69,France,2016 Summer,Fencing,"Fencing Women's Sabre, Team",NA
+Sid Ali Boudina,M,26,178,73,Algeria,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Adem Boudjemline,M,22,180,85,Algeria,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",NA
+Marcelle Cecilia Bouele Bondo,F,23,166,60,Congo (Brazzaville),2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Farah Boufadene,F,17,155,55,Algeria,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Farah Boufadene,F,17,155,55,Algeria,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Farah Boufadene,F,17,155,55,Algeria,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Farah Boufadene,F,17,155,55,Algeria,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Oussama Al-Boughanmi,M,26,185,87,Tunisia,2016 Summer,Handball,Handball Men's Handball,NA
+Sarah Bouhaddi,F,29,175,69,France,2016 Summer,Football,Football Women's Football,NA
+Terry Bouhraoua,M,28,169,65,France,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+David Sylvre Patrick Boui,M,28,187,68,Central African Republic,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,NA
+Kawtar Boulaid,F,26,159,45,Morocco,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Chouaib Bouloudinats,M,29,183,91,Algeria,2016 Summer,Boxing,Boxing Men's Heavyweight,NA
+Kvin Bouly,M,35,177,95,France,2016 Summer,Weightlifting,Weightlifting Men's Middle-Heavyweight,NA
+Baghdad Bounedjah,M,24,189,75,Algeria,2016 Summer,Football,Football Men's Football,NA
+Soufiyan Bouqantar,M,22,173,54,Morocco,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Hamza Bouras,M,28,170,73,Algeria,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+Grgory Bourdy,M,34,180,70,France,2016 Summer,Golf,Golf Men's Individual,NA
+Lorys Bourelly,M,24,184,69,France,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Mohamed Abdeldjalil Bourguieg,M,19,164,50,Algeria,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Mohamed Abdeldjalil Bourguieg,M,19,164,50,Algeria,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Mohamed Abdeldjalil Bourguieg,M,19,164,50,Algeria,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Mohamed Abdeldjalil Bourguieg,M,19,164,50,Algeria,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Mohamed Abdeldjalil Bourguieg,M,19,164,50,Algeria,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Mohamed Abdeldjalil Bourguieg,M,19,164,50,Algeria,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Jean-Pierre Renan Bourhis,M,21,178,73,Senegal,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",NA
+Larbi Bourrada,M,28,188,88,Algeria,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+"Frdric Thierry Roger ""Frd"" Bousquet",M,35,188,86,France,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Sofian Bouvet,M,27,173,63,France,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Carline Bouw,F,31,184,72,Netherlands,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,Silver
+Marit Bouwmeester,F,28,177,68,Netherlands,2016 Summer,Sailing,Sailing Women's One Person Dinghy,Gold
+Lyes Bouyacoub,M,33,185,100,Algeria,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Alexandre Bouzaid,M,35,168,75,Senegal,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+George Richard Lycott Bovell,M,33,196,74,Trinidad and Tobago,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Scott Bowden,M,21,175,65,Australia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Scott Bowden,M,21,175,65,Australia,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Alex Bowen,M,22,196,102,United States,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+"Kate Elizabeth ""Katie"" Bowen-Duncan",F,22,172,56,New Zealand,2016 Summer,Football,Football Women's Football,NA
+"Frentorish ""Tori"" Bowie",F,25,175,58,United States,2016 Summer,Athletics,Athletics Women's 100 metres,Silver
+"Frentorish ""Tori"" Bowie",F,25,175,58,United States,2016 Summer,Athletics,Athletics Women's 200 metres,Bronze
+"Frentorish ""Tori"" Bowie",F,25,175,58,United States,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,Gold
+Daniel Bowker,M,28,191,89,Australia,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+Brenda Bowskill,F,24,170,68,Canada,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Brendan Boyce,M,29,183,76,Ireland,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Alana Boyd,F,32,171,59,Australia,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+"Danielle ""Dannie"" Boyd",F,26,178,71,Canada,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Marine Clmence Boyer,F,16,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Marine Clmence Boyer,F,16,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Marine Clmence Boyer,F,16,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Lauren Marie Boyle,F,28,183,67,New Zealand,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Lauren Marie Boyle,F,28,183,67,New Zealand,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,NA
+Francisco Boza Dibos,M,51,176,95,Peru,2016 Summer,Shooting,Shooting Men's Trap,NA
+Georgi Bozhilov,M,27,201,107,Bulgaria,2016 Summer,Rowing,Rowing Men's Double Sculls,NA
+Luka Boi,M,25,173,72,Slovenia,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, Slalom",NA
+Elisa Bozzo,F,29,170,58,Italy,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Frederik Lindbg Brsting,M,21,184,78,Denmark,2016 Summer,Football,Football Men's Football,NA
+Roel Hubertus Braas,M,29,200,100,Netherlands,2016 Summer,Rowing,Rowing Men's Coxless Pairs,NA
+Josu Brachi Garca,M,23,156,56,Spain,2016 Summer,Weightlifting,Weightlifting Men's Bantamweight,NA
+Marvin Bracy,M,22,175,78,United States,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Rui Pedro Rebelo Bragana,M,24,180,58,Portugal,2016 Summer,Taekwondo,Taekwondo Men's Flyweight,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Pablo Dominic Brgger,M,23,169,64,Switzerland,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Luca Braidot,M,25,179,69,Italy,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Michael Brake,M,21,187,91,New Zealand,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Jovana Brakoevi-Kancian,F,28,196,82,Serbia,2016 Summer,Volleyball,Volleyball Women's Volleyball,Silver
+Mario Alfonso Bran Granillo,M,26,168,64,Guatemala,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Cristina Direito Branco,F,31,172,68,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Isabel Brand Leu,F,20,169,53,Guatemala,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,NA
+David Karl Brandl,M,29,187,82,Austria,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Dorothea Brandt,F,32,178,70,Germany,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Julian Brandt,M,20,183,83,Germany,2016 Summer,Football,Football Men's Football,Silver
+"Nathan ""Nate"" Brannen",M,33,174,58,Canada,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Mara Branz,F,26,170,68,Argentina,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Ana Maria Florentina Brnz-Popescu,F,31,175,64,Romania,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Ana Maria Florentina Brnz-Popescu,F,31,175,64,Romania,2016 Summer,Fencing,"Fencing Women's epee, Team",Gold
+Yannick Brauchli,M,28,173,63,Switzerland,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Sarah-Anne Brault,F,26,171,65,Canada,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Anton Braun,M,26,202,104,Germany,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Pieter Braun,M,23,186,83,Netherlands,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Albert Idel Bravo Morales,M,28,199,88,Venezuela,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Albert Idel Bravo Morales,M,28,199,88,Venezuela,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Elizabeth Mara Bravo iguez,F,29,160,49,Ecuador,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Marina Bravo Bragado,F,27,173,68,Spain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Sophie Charlotte Bray,F,26,164,58,Great Britain,2016 Summer,Hockey,Hockey Women's Hockey,Gold
+Thiago Braz da Silva,M,22,183,75,Brazil,2016 Summer,Athletics,Athletics Men's Pole Vault,Gold
+Kelly Brazier,F,26,171,70,New Zealand,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Silver
+Stefano Brecciaroli,M,41,177,71,Italy,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Stefano Brecciaroli,M,41,177,71,Italy,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Elson Viney-Bartel Brechtefeld,M,22,155,56,Nauru,2016 Summer,Weightlifting,Weightlifting Men's Bantamweight,NA
+Melissa Breen,F,25,174,65,Australia,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Vincent Breet,M,23,195,92,South Africa,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Andre Breitbarth,M,26,191,125,Germany,2016 Summer,Judo,Judo Men's Heavyweight,NA
+Odd Arne Brekne,M,31,182,NA,Norway,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Odd Arne Brekne,M,31,182,NA,Norway,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Nils Brembach,M,23,184,70,Germany,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Sebastian Brendel,M,28,192,92,Germany,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 1,000 metres",Gold
+Sebastian Brendel,M,28,192,92,Germany,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, 1,000 metres",Gold
+Nery Antonio Brenes Crdenas,M,30,175,70,Costa Rica,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Nery Antonio Brenes Crdenas,M,30,175,70,Costa Rica,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Lisa Brennauer,F,28,168,63,Germany,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Lisa Brennauer,F,28,168,63,Germany,2016 Summer,Cycling,Cycling Women's Individual Time Trial,NA
+Klaudia Bre,F,22,158,52,Poland,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Klaudia Bre,F,22,158,52,Poland,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Luis Brethauer,M,23,176,82,Germany,2016 Summer,Cycling,Cycling Men's BMX,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Andreas Bretschneider,M,26,167,60,Germany,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Marine Grace Brevet,F,21,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Marine Grace Brevet,F,21,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Marine Grace Brevet,F,21,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Marine Grace Brevet,F,21,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Marine Grace Brevet,F,21,162,52,France,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Andrea Brewster,F,33,163,62,Ireland,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Darko Brguljan,M,25,180,97,Montenegro,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Drako Brguljan,M,31,194,92,Montenegro,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Morgan Paige Brian,F,23,170,58,United States,2016 Summer,Football,Football Women's Football,NA
+Thomas Felipe Briceo Gonzlez,M,22,186,90,Chile,2016 Summer,Judo,Judo Men's Middleweight,NA
+George Spencer Bridgewater,M,33,200,97,New Zealand,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Thomas Briels,M,28,172,71,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+Stphanie Brieussel,F,42,169,55,France,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Stphanie Brieussel,F,42,169,55,France,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Maxime Brinck-Croteau,M,30,178,83,Canada,2016 Summer,Fencing,"Fencing Men's epee, Individual",NA
+Christine Brinker-Wenzel,F,35,171,63,Germany,2016 Summer,Shooting,Shooting Women's Skeet,NA
+Leidys Milagros Brito,F,32,169,52,Venezuela,2016 Summer,Archery,Archery Women's Individual,NA
+Stefan Brits,M,24,183,72,South Africa,2016 Summer,Athletics,Athletics Men's Long Jump,NA
+Lawrence Brittain,M,25,187,94,South Africa,2016 Summer,Rowing,Rowing Men's Coxless Pairs,Silver
+Fionnuala Britton-McCormack,F,31,159,46,Ireland,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Laurence Brize,F,40,158,55,France,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Sarah Bro,F,20,177,64,Denmark,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Yvette Broch,F,25,184,73,Netherlands,2016 Summer,Handball,Handball Women's Handball,NA
+Allison M. Brock,F,36,168,59,United States,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Allison M. Brock,F,36,168,59,United States,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",Bronze
+Nicolai Brock-Madsen,M,23,194,88,Denmark,2016 Summer,Football,Football Men's Football,NA
+Jamie Lynn Broder,F,31,172,65,Canada-2,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Greg Patrick Broderick,M,30,180,50,Ireland,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Daniel Brodmeier,M,28,180,100,Germany,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Daniel Brodmeier,M,28,180,100,Germany,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Ryan Broekhoff,M,25,201,93,Australia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Nadine Martina Broersen,F,26,171,62,Netherlands,2016 Summer,Athletics,Athletics Women's Heptathlon,NA
+Alastair Richard Brogdon,M,28,183,76,Great Britain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Enrique Brol Cardenas,M,37,181,73,Guatemala,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+Hebert Brol Cardenas,M,36,181,80,Guatemala,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+Trayvon Jaquez Bromell,M,21,175,70,United States,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Trayvon Jaquez Bromell,M,21,175,70,United States,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Viktor Bregner Bromer,M,23,194,87,Denmark,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Giorgia Bronzini,F,33,160,54,Italy,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+"Christopher Dean ""Chris"" Brooks",M,29,173,75,United States,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Kristina Brring-Sprehe,F,29,168,54,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",Bronze
+Kristina Brring-Sprehe,F,29,168,54,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",Gold
+Julie Brougham,F,62,157,48,New Zealand,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Gayle Broughton,F,20,174,70,New Zealand,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Silver
+Alexander Brouwer,M,26,198,88,Netherlands-1,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,Bronze
+Aaron Brown,M,24,198,79,Canada,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Aaron Brown,M,24,198,79,Canada,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Aaron Brown,M,24,198,79,Canada,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Bronze
+"Abigail ""Abbie"" Brown",F,20,176,71,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Alicia Brown,F,26,165,57,Canada,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Alicia Brown,F,26,165,57,Canada,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+"Christopher Deon ""Chris"" Brown",M,37,178,75,Bahamas,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+"Christopher Deon ""Chris"" Brown",M,37,178,75,Bahamas,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,Bronze
+Colton Brown,M,24,183,91,United States,2016 Summer,Judo,Judo Men's Middleweight,NA
+Devon Myles William Brown,M,24,188,80,South Africa,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Devon Myles William Brown,M,24,188,80,South Africa,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Devon Myles William Brown,M,24,188,80,South Africa,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Devon Myles William Brown,M,24,188,80,South Africa,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Dustin Brown,M,31,196,78,Germany,2016 Summer,Tennis,Tennis Men's Singles,NA
+Ashani Kemarley Brown,M,24,182,85,Bahrain,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Kyle Gie Brown,M,29,182,92,South Africa,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Bronze
+Laura Brown,F,29,167,61,Canada,2016 Summer,Cycling,Cycling Women's Team Pursuit,Bronze
+Mackenzie Brown,F,21,178,75,United States,2016 Summer,Archery,Archery Women's Individual,NA
+Will Brown,M,24,170,61,United States,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Will Brown,M,24,170,61,United States,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Alistair Edward Brownlee,M,28,184,70,Great Britain,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,Gold
+"Jonathan Callum ""Jonny"" Brownlee",M,26,181,70,Great Britain,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,Silver
+Ilija Brozovi,M,25,196,109,Croatia,2016 Summer,Handball,Handball Men's Handball,NA
+"Lucas ""Luc"" Bruchet",M,25,183,69,Canada,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Nathalie Brugger,F,30,174,69,Switzerland,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Annika Bruhn,F,23,183,69,Germany,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Annika Bruhn,F,23,183,69,Germany,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Annika Bruhn,F,23,183,69,Germany,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Henricho Bruintjies,M,23,179,72,South Africa,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Ese Brume,F,20,167,58,Nigeria,2016 Summer,Athletics,Athletics Women's Long Jump,NA
+Kristoffer Brun,M,28,175,70,Norway,2016 Summer,Rowing,Rowing Men's Lightweight Double Sculls,Bronze
+Bruna Beatriz Benites Soares,F,30,178,65,Brazil,2016 Summer,Football,Football Women's Football,NA
+Manon Brunet,F,20,165,55,France,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Manon Brunet,F,20,165,55,France,2016 Summer,Fencing,"Fencing Women's Sabre, Team",NA
+Manuel Brunet,M,30,179,79,Argentina,2016 Summer,Hockey,Hockey Men's Hockey,Gold
+Rachele Bruni,F,25,170,59,Italy,2016 Summer,Swimming,Swimming Women's 10 kilometres Open Water,Silver
+"Bruno ""Bruninho"" Mossa de Rezende",M,30,190,76,Brazil,2016 Summer,Volleyball,Volleyball Men's Volleyball,Gold
+Federico Bruno,M,23,185,66,Argentina,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Maria Bruno,F,23,160,54,Brazil,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Nicols Martn Bruno,M,27,187,85,Argentina,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Nicols Brussino,M,23,200,84,Argentina,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Nicols Bruzzone,M,30,169,76,Argentina,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Aleksey Sergeyevich Bryansky,M,18,192,82,Russia,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Ole-Kristian Bryhn,M,27,189,NA,Norway,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Ole-Kristian Bryhn,M,27,189,NA,Norway,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Ole-Kristian Bryhn,M,27,189,NA,Norway,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Aleksandr Aleksandrovich Bryukhankov,M,29,184,79,Russia,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Yelyzaveta Viktorivna Bryzhina,F,26,173,63,Ukraine,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Yelyzaveta Viktorivna Bryzhina,F,26,173,63,Ukraine,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Marcin Mariusz Brzeziski,M,32,194,98,Poland,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Maarten Brzoskowski,M,20,185,79,Netherlands,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Maarten Brzoskowski,M,20,185,79,Netherlands,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Monika Brzostek,F,27,173,62,Poland,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Artur Brzozowski,M,31,174,67,Poland,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Matelita Buadromo,F,20,171,56,Fiji,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Keerati Bualong,M,23,181,82,Thailand,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Bedopassa Buassat Djonde,M,23,172,97,Guinea Bissau,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Joshua Buatsi,M,23,185,81,Great Britain,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,Bronze
+Andreas Hjartbro Bube,M,29,178,65,Denmark,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Mat Bubenik,M,26,197,78,Slovakia,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Vitaly Ivanovich Bubnovich,M,41,169,70,Belarus,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Vitaly Ivanovich Bubnovich,M,41,169,70,Belarus,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Eliza-Iulia Buceschi,F,23,178,70,Romania,2016 Summer,Handball,Handball Women's Handball,NA
+Caroline Buchanan,F,25,165,68,Australia,2016 Summer,Cycling,Cycling Women's BMX,NA
+Kadeisha Buchanan,F,20,170,65,Canada,2016 Summer,Football,Football Women's Football,Bronze
+Rushlee Buchanan,F,28,170,63,New Zealand,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Selina Christina Bchel,F,25,167,57,Switzerland,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Ralf Buchheim,M,32,183,72,Germany,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Nicole Bchler,F,32,162,54,Switzerland,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+Matthijs Bchli,M,23,188,90,Netherlands,2016 Summer,Cycling,Cycling Men's Keirin,Silver
+Matthijs Bchli,M,23,188,90,Netherlands,2016 Summer,Cycling,Cycling Men's Team Sprint,NA
+Emanuel Buchmann,M,23,181,61,Germany,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Charlie Buckingham,M,27,188,82,United States,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Hannah Buckling,F,24,177,75,Australia,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Zoe Buckman,F,27,168,50,Australia,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Rosane Sibele Budag Ewald,F,42,174,66,Brazil,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Rosane Sibele Budag Ewald,F,42,174,66,Brazil,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Siri Arun Budcharern,F,14,166,63,Laos,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Serhiy Volodymyrovych Budza,M,31,180,75,Ukraine,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Tiril Merete Hartvedt Bue,F,23,180,NA,Norway,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Marco Antonio Bueno Ontiveros,M,22,182,64,Mexico,2016 Summer,Football,Football Men's Football,NA
+Philipp Buhl,M,26,187,85,Germany,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Lrke Buhl-Hansen,F,24,167,56,Denmark,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Matas Bhler,M,33,176,77,Switzerland,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Matthias Bhler,M,29,189,78,Germany,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Kim Bui,F,27,155,49,Germany,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Kim Bui,F,27,155,49,Germany,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Kim Bui,F,27,155,49,Germany,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Anne Buijs,F,24,191,73,Netherlands,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Cristina Ioana Bujin,F,28,172,56,Romania,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+Barbara Bujka,F,29,172,82,Hungary,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Mandy Marie Brigitte Bujold,F,29,160,51,Canada,2016 Summer,Boxing,Boxing Women's Flyweight,NA
+Mabika Yolande Bukasa,F,28,170,70,Refugee Olympic Athletes,2016 Summer,Judo,Judo Women's Middleweight,NA
+Luka Buki,M,22,195,90,Croatia,2016 Summer,Water Polo,Water Polo Men's Water Polo,Silver
+Yekaterina Borisovna Bukina,F,29,174,75,Russia,2016 Summer,Wrestling,"Wrestling Women's Heavyweight, Freestyle",Bronze
+Konrad Bukowiecki,M,19,191,138,Poland,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Anela Bulatovi,F,29,175,67,Montenegro,2016 Summer,Handball,Handball Women's Handball,NA
+Katarina Bulatovi,F,31,186,71,Montenegro,2016 Summer,Handball,Handball Women's Handball,NA
+"Ana Beatriz ""Bia"" di Rienzo Bulco",F,22,167,58,Brazil,2016 Summer,Fencing,"Fencing Women's Foil, Individual",NA
+Alyssa Bull,F,20,173,65,Australia,2016 Summer,Canoeing,"Canoeing Women's Kayak Doubles, 500 metres",NA
+Chlo Bulleux,F,24,172,65,France,2016 Summer,Handball,Handball Women's Handball,Silver
+"Pieter ""Piet"" Bulling",M,23,179,77,New Zealand,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",NA
+Michael Bultheel,M,30,189,81,Belgium,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Johanna Bundsen,F,25,185,72,Sweden,2016 Summer,Handball,Handball Women's Handball,NA
+Seren Bundy-Davies,F,21,175,63,Great Britain,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Tairat Bunsuk,M,23,161,69,Thailand,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Porntip Buranaprasertsuk,F,24,165,61,Thailand,2016 Summer,Badminton,Badminton Women's Singles,NA
+Mikoaj Piotr Burda,M,34,192,98,Poland,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Phil Burgess,M,28,180,92,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Silver
+Lely Berlitt Burgos Ortz,F,31,153,50,Puerto Rico,2016 Summer,Weightlifting,Weightlifting Women's Featherweight,NA
+Olena Sviatoslavivna Buriak,F,28,196,90,Ukraine,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,NA
+Damir Buri,M,35,205,115,Croatia,2016 Summer,Water Polo,Water Polo Men's Water Polo,Silver
+Gelete Burka Bati,F,30,160,43,Ethiopia,2016 Summer,Athletics,"Athletics Women's 10,000 metres",NA
+Steven James Burke,M,28,183,78,Great Britain,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",Gold
+Peter Burling,M,25,186,82,New Zealand,2016 Summer,Sailing,Sailing Men's Skiff,Gold
+Pedro Luiz Burmann de Oliveira,M,24,180,83,Brazil,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Jack David Burnell,M,23,185,72,Great Britain,2016 Summer,Swimming,Swimming Men's 10 kilometres Open Water,NA
+Alyce Burnett,F,23,182,71,Australia,2016 Summer,Canoeing,"Canoeing Women's Kayak Doubles, 500 metres",NA
+Jason Nicholas Burnett,M,29,165,68,Canada,2016 Summer,Trampolining,Trampolining Men's Individual,NA
+Jordan Ernest Burroughs,M,28,171,79,United States,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Freestyle",NA
+Christopher Burton,M,34,180,70,Australia,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Christopher Burton,M,34,180,70,Australia,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",Bronze
+Natalie Burton,F,27,194,76,Australia,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Tom Burton,M,26,180,81,Australia,2016 Summer,Sailing,Sailing Men's One Person Dinghy,Gold
+Aleksandr Ivanovich Bury,M,28,203,93,Belarus,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Bianka Bua,F,22,187,74,Serbia,2016 Summer,Volleyball,Volleyball Women's Volleyball,Silver
+Andro Bulje,M,30,200,115,Croatia,2016 Summer,Water Polo,Water Polo Men's Water Polo,Silver
+Florencia Natasha Busquets Reyes,F,27,192,68,Argentina,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+lise Bussaglia,F,30,163,56,France,2016 Summer,Football,Football Women's Football,NA
+Tho Bussire,M,21,188,90,France,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+David Bustos Gonzlez,M,25,182,64,Spain,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Rafa Buszek,M,29,195,92,Poland,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+"Andrew ""Andy"" Butchart",M,24,175,64,Great Britain,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Chatchai Butdee,M,31,166,52,Thailand,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Britta Kristin Bthe,F,28,185,78,Germany-2,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Simone Buti,M,32,206,100,Italy,2016 Summer,Volleyball,Volleyball Men's Volleyball,Silver
+Geoffrey Butler,M,20,188,84,Cayman Islands,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Jimmy Butler III,M,26,201,99,United States,2016 Summer,Basketball,Basketball Men's Basketball,Gold
+Lara Butler,F,21,172,60,Cayman Islands,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Vitaliy Mykolaiovych Butrym,M,25,180,75,Ukraine,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Mykola Valeriyovych Butsenko,M,25,170,56,Ukraine,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Linus Butt,M,29,186,83,Germany,2016 Summer,Hockey,Hockey Men's Hockey,Bronze
+Dajana Butulija,F,30,175,65,Serbia,2016 Summer,Basketball,Basketball Women's Basketball,Bronze
+Aleksandr Nikolayevich Buykevich,M,31,191,80,Belarus,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Kimberly Buys,F,27,187,75,Belgium,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+ala Bykakay,F,26,172,58,Turkey,2016 Summer,Tennis,Tennis Women's Singles,NA
+Rafael Augusto Buzacarini,M,24,183,100,Brazil,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Paulina Buziak,F,29,170,48,Poland,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Byambyn Tvshinbat,M,29,174,69,Mongolia,2016 Summer,Boxing,Boxing Men's Welterweight,NA
+Byeon Yeong-Jun,M,32,175,59,South Korea,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Atheyna Bylon,F,27,175,75,Panama,2016 Summer,Boxing,Boxing Women's Middleweight,NA
+Sven Erik Bystrm,M,24,188,72,Norway,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Nathan Byukusenge,M,35,NA,NA,Rwanda,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Juan Sebastin Cabal Valds,M,30,185,82,Colombia,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Denia Caballero Ponce,F,26,175,70,Cuba,2016 Summer,Athletics,Athletics Women's Discus Throw,Bronze
+Ana Isabel Vermelhudo Cabecinha,F,32,163,48,Portugal,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Alexandrina Cabral Barbosa,F,30,175,62,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+"Donald ""Donn"" Cabral",M,26,178,68,United States,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Francelina Cabral,F,31,165,NA,Timor Leste,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Johnathan Knight Cabral,M,23,190,84,Canada,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Juan Carlos Cabrera Prez,M,24,194,105,Mexico,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Lani Rose Cabrera,F,23,175,66,Barbados,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Rafael Cabrera Bello,M,32,187,83,Spain,2016 Summer,Golf,Golf Men's Individual,NA
+Juan Ignacio Cceres,M,24,168,75,Argentina,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Kateina Cachov,F,26,171,63,Czech Republic,2016 Summer,Athletics,Athletics Women's Heptathlon,NA
+Levi Asher Cadogan,M,20,181,78,Barbados,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Jrmy Cadot,M,29,185,78,France,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Jrmy Cadot,M,29,185,78,France,2016 Summer,Fencing,"Fencing Men's Foil, Team",Silver
+Florent Caelen,M,27,175,54,Belgium,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Basten Caerts,M,18,185,85,Belgium,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Bahar alar,F,27,190,76,Turkey,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Tania Cagnotto (-Parolin),F,31,160,54,Italy,2016 Summer,Diving,Diving Women's Springboard,Bronze
+Tania Cagnotto (-Parolin),F,31,160,54,Italy,2016 Summer,Diving,Diving Women's Synchronized Springboard,Silver
+Cai Zelin,M,25,175,55,China,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,Silver
+Andrs Mauricio Caicedo Piedrahita,M,18,174,75,Colombia,2016 Summer,Weightlifting,Weightlifting Men's Middleweight,NA
+Chiara Cainero,F,38,171,81,Italy,2016 Summer,Shooting,Shooting Women's Skeet,Silver
+Anne Cairns,F,35,NA,NA,Samoa,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 200 metres",NA
+Anne Cairns,F,35,NA,NA,Samoa,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 500 metres",NA
+Olcay akr,F,23,182,60,Turkey,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Lucas Calabrese,M,29,168,60,Argentina,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Hugo Marinho Borges Calderano,M,20,182,74,Brazil,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Hugo Marinho Borges Calderano,M,20,182,74,Brazil,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Jos Manuel Caldern Borrallo,M,34,191,90,Spain,2016 Summer,Basketball,Basketball Men's Basketball,Bronze
+Hilary Caldwell,F,25,173,61,Canada,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,Bronze
+Briken Calja,M,26,170,69,Albania,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Mara Elena Calle Galarza,F,41,162,54,Ecuador,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Beatrice Callegari,F,24,175,59,Italy,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Emmanuel Earl Callender,M,32,189,86,Trinidad and Tobago,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Jonathan Calleri,M,22,179,75,Argentina,2016 Summer,Football,Football Men's Football,NA
+Facundo Callioni,M,30,183,77,Argentina,2016 Summer,Hockey,Hockey Men's Hockey,Gold
+Mlina Clugreanu,F,19,176,66,Romania,2016 Summer,Fencing,"Fencing Women's Foil, Individual",NA
+Eva Calvo Gmez,F,25,176,57,Spain,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,Silver
+Jossimar Orlando Calvo Moreo,M,22,160,54,Colombia,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Jossimar Orlando Calvo Moreo,M,22,160,54,Colombia,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Jossimar Orlando Calvo Moreo,M,22,160,54,Colombia,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Jossimar Orlando Calvo Moreo,M,22,160,54,Colombia,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Jossimar Orlando Calvo Moreo,M,22,160,54,Colombia,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Jossimar Orlando Calvo Moreo,M,22,160,54,Colombia,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Tania Calvo Barbero,F,24,166,64,Spain,2016 Summer,Cycling,Cycling Women's Sprint,NA
+Tania Calvo Barbero,F,24,166,64,Spain,2016 Summer,Cycling,Cycling Women's Keirin,NA
+Tania Calvo Barbero,F,24,166,64,Spain,2016 Summer,Cycling,Cycling Women's Team Sprint,NA
+Alyn Camara,M,27,196,84,Germany,2016 Summer,Athletics,Athletics Men's Long Jump,NA
+Amadou Camara,M,22,163,69,Guinea,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Alexandre Camarasa,M,29,193,100,France,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Alexandre Camargo,M,17,177,75,Brazil,2016 Summer,Fencing,"Fencing Men's epee, Team",NA
+"Elizabeth Folake ""Liz"" Cambage",F,24,203,98,Australia,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Mattia Camboni,M,20,180,70,Italy,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+"Asuka Antonio ""Aska"" Cambridge",M,23,179,74,Japan,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+"Asuka Antonio ""Aska"" Cambridge",M,23,179,74,Japan,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Silver
+Tiago Henrique de Oliveira Camilo,M,34,180,90,Brazil,2016 Summer,Judo,Judo Men's Middleweight,NA
+Yssica Camilo Gonzlez,F,23,168,73,Dominican Republic,2016 Summer,Archery,Archery Women's Individual,NA
+Facundo Campazzo,M,25,181,85,Argentina,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Alan Campbell,M,33,191,96,Great Britain,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Amber Campbell,F,35,171,90,United States,2016 Summer,Athletics,Athletics Women's Hammer Throw,NA
+"Andrew Campbell, Jr.",M,24,178,70,United States,2016 Summer,Rowing,Rowing Men's Lightweight Double Sculls,NA
+Bronte Campbell,F,22,179,58,Australia,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Bronte Campbell,F,22,179,58,Australia,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Bronte Campbell,F,22,179,58,Australia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,Gold
+Cate Natalie Campbell,F,24,186,67,Australia,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Cate Natalie Campbell,F,24,186,67,Australia,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Cate Natalie Campbell,F,24,186,67,Australia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,Gold
+Cate Natalie Campbell,F,24,186,67,Australia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,Silver
+Kemoy Campbell,M,25,168,57,Jamaica,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+"Richard ""Richie"" Campbell",M,28,193,99,Australia,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Simoya Kadine Campbell,F,22,167,54,Jamaica,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Veronica Angella Campbell-Brown,F,34,168,58,Jamaica,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Veronica Angella Campbell-Brown,F,34,168,58,Jamaica,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,Silver
+Roco Campigli,F,21,173,70,Argentina,2016 Summer,Handball,Handball Women's Handball,NA
+Kvin Campion,M,28,183,63,France,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Alfredo Jos Campo Vintimilla,M,23,192,90,Ecuador,2016 Summer,Cycling,Cycling Men's BMX,NA
+Jorge Moiss Campos Valds,M,24,184,77,Cuba,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Lus Henry Campos Cruz,M,20,166,61,Peru,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Luiza Gonzalez da Costa Campos,F,26,165,64,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Mara Pilar Campoy,F,25,158,48,Argentina,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Niccol Campriani,M,28,177,80,Italy,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",Gold
+Niccol Campriani,M,28,177,80,Italy,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",Gold
+Niccol Campriani,M,28,177,80,Italy,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Daniela Campuzano Chvez Pen,F,29,173,56,Mexico,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Yasemin Can,F,19,166,49,Turkey,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Yasemin Can,F,19,166,49,Turkey,2016 Summer,Athletics,"Athletics Women's 10,000 metres",NA
+Kelvin Jos Caa Infante,M,28,173,72,Venezuela,2016 Summer,Fencing,"Fencing Men's epee, Team",NA
+Fabian Cancellara,M,35,186,81,Switzerland,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Fabian Cancellara,M,35,186,81,Switzerland,2016 Summer,Cycling,Cycling Men's Individual Time Trial,Gold
+Marie-Florence Candassamy,F,25,185,74,France,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Marie-Florence Candassamy,F,25,185,74,France,2016 Summer,Fencing,"Fencing Women's epee, Team",NA
+Yann Candele,M,45,173,82,Canada,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Yann Candele,M,45,173,82,Canada,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Julien Candelon,M,36,170,80,France,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Lucas Benedito Cndido,M,27,185,88,Brazil,2016 Summer,Handball,Handball Men's Handball,NA
+Hersony Gadiel Caneln Vera,M,27,176,73,Venezuela,2016 Summer,Cycling,Cycling Men's Sprint,NA
+Hersony Gadiel Caneln Vera,M,27,176,73,Venezuela,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Hersony Gadiel Caneln Vera,M,27,176,73,Venezuela,2016 Summer,Cycling,Cycling Men's Team Sprint,NA
+Marina Canetta Gobbi,F,27,162,51,Brazil,2016 Summer,Archery,Archery Women's Individual,NA
+Marina Canetta Gobbi,F,27,162,51,Brazil,2016 Summer,Archery,Archery Women's Team,NA
+Marina Canetti,F,33,169,63,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Tue Cantez,F,25,188,85,Turkey,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Juan Manuel Cano Ceres,M,28,168,60,Argentina,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Karol-Ann Canuel,F,28,163,51,Canada,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Karol-Ann Canuel,F,28,163,51,Canada,2016 Summer,Cycling,Cycling Women's Individual Time Trial,NA
+Cao Hui,F,24,175,70,China,2016 Summer,Archery,Archery Women's Individual,NA
+Cao Hui,F,24,175,70,China,2016 Summer,Archery,Archery Women's Team,NA
+Cao Shuo,M,24,180,77,China,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Cao Yifei,M,28,175,75,China,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Cao Yifei,M,28,175,75,China,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Cao Yuan,M,21,160,42,China,2016 Summer,Diving,Diving Men's Springboard,Gold
+Cao Yuan,M,21,160,42,China,2016 Summer,Diving,Diving Men's Synchronized Springboard,Bronze
+Cao Yue,F,20,178,72,China,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Cao Zhongrong,M,34,180,73,China,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Vincenzo Maria Capelli,M,27,193,96,Italy,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Teodorico Caporaso,M,28,166,60,Italy,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Rafael Da Costa Capote,M,28,196,109,Qatar,2016 Summer,Handball,Handball Men's Handball,NA
+Manuel Fabrizio Cappai,M,23,168,49,Italy,2016 Summer,Boxing,Boxing Men's Light-Flyweight,NA
+Corina Oana Cprioriu,F,30,161,57,Romania,2016 Summer,Judo,Judo Women's Lightweight,NA
+Dumitru Captari,M,27,168,79,Romania,2016 Summer,Weightlifting,Weightlifting Men's Middleweight,NA
+Erwin Jos Caraballo Cabrera,M,35,185,130,Venezuela,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Greco-Roman",NA
+Adrian Ignacio Carambula Raurich,M,28,183,84,Italy-2,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Marzia Caravelli,F,34,177,62,Italy,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Ona Carbonell Ballestero,F,26,174,54,Spain,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Kelsey Card,F,23,178,116,United States,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Felipe Crdenas Morales,M,25,183,75,Chile,2016 Summer,Rowing,Rowing Men's Lightweight Double Sculls,NA
+Andr Fernando dos Santos Martins Cardoso,M,31,168,57,Portugal,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Daniela Bruno Stoffel Cardoso,F,24,157,47,Portugal,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+"Christopher ""Chris"" Cargo",M,30,182,79,Ireland,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Diletta Carli,F,20,170,61,Italy,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+"Jazmin Roxy ""Jazz"" Carlin",F,25,175,57,Great Britain,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,Silver
+"Jazmin Roxy ""Jazz"" Carlin",F,25,175,57,Great Britain,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,Silver
+Azenaide Danila Jos Carlos,F,26,175,69,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Ryan Carlyle,F,26,168,66,United States,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Sara Lopez Mota Carmo,F,29,179,69,Portugal,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Samuel Carmona Heredia,M,20,162,49,Spain,2016 Summer,Boxing,Boxing Men's Light-Flyweight,NA
+Priscilla Andreia Stevaux Carnaval,F,22,156,58,Brazil,2016 Summer,Cycling,Cycling Women's BMX,NA
+Olivia Frances Carnegie-Brown,F,25,181,73,Great Britain,2016 Summer,Rowing,Rowing Women's Coxed Eights,Silver
+Laurent Carnol,M,26,187,82,Luxembourg,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Laurent Carnol,M,26,187,82,Luxembourg,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Danilo Caro Guarnieri,M,50,175,74,Colombia,2016 Summer,Shooting,Shooting Men's Trap,NA
+Gonzalo Matas Carou,M,36,190,100,Argentina,2016 Summer,Handball,Handball Men's Handball,NA
+Ellie Madison Carpenter,F,16,165,59,Australia,2016 Summer,Football,Football Women's Football,NA
+Amanda Mildred Carr,F,26,165,60,Thailand,2016 Summer,Cycling,Cycling Women's BMX,NA
+Cecilia Carranza Saroli,F,29,164,63,Argentina,2016 Summer,Sailing,Sailing Mixed Multihull,Gold
+Daniela Matarazzo Carraro,F,31,165,67,Brazil,2016 Summer,Shooting,Shooting Women's Skeet,NA
+Martina Carraro,F,23,175,60,Italy,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Marisol Carrat,F,30,174,85,Argentina,2016 Summer,Handball,Handball Women's Handball,NA
+Cyrille Carr,M,32,184,75,France,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 1,000 metres",NA
+Cyrille Carr,M,32,184,75,France,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Jorge Carrera Oliva,M,34,180,83,Spain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+scar Carrera Amandi,M,25,190,86,Spain,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Pablo Abensaid Carrera Vzquez,M,30,182,93,Spain,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Pablo Abensaid Carrera Vzquez,M,30,182,93,Spain,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Gonzalo Carreras,M,26,186,88,Argentina,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Yaniel Carrero Zambrano,M,20,174,74,Cuba,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Edna Guadalupe Carrillo Torres,F,24,185,78,Mexico,2016 Summer,Judo,Judo Women's Extra-Lightweight,NA
+Juan Carlos Carrillo Palacio,M,23,184,81,Colombia,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,NA
+Marko Carrillo Zevallos,M,28,184,75,Peru,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Marko Carrillo Zevallos,M,28,184,75,Peru,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+Marko Carrillo Zevallos,M,28,184,75,Peru,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Yeseida Isaid Carrillo Torres,F,22,168,52,Colombia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Lisa Carrington,F,27,168,63,New Zealand,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 200 metres",Gold
+Lisa Carrington,F,27,168,63,New Zealand,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 500 metres",Bronze
+Javier Mario Carrin Llorens,M,25,188,100,Spain,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Fernando Carro Morillo,M,24,170,60,Spain,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Hamish Carson,M,27,181,66,New Zealand,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Carolena Jean Carstens Salceda,F,20,168,57,Panama,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,NA
+David Carter,M,34,175,79,Canada,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Deuce Carter,M,25,183,82,Jamaica,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Dylan Carter,M,20,190,82,Trinidad and Tobago,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Michelle Denee Carter,F,30,176,136,United States,2016 Summer,Athletics,Athletics Women's Shot Put,Gold
+Louise Carton,F,22,172,57,Belgium,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Damiano Caruso,M,28,179,65,Italy,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Damiano Caruso,M,28,179,65,Italy,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Peter Caruth,M,28,173,73,Ireland,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Diogo Filipe Silva de Carvalho,M,28,184,75,Portugal,2016 Summer,Swimming,Swimming Men's 200 metres Individual Medley,NA
+Florian Carvalho,M,27,183,70,France,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Jos Fernando Saraiva Carvalho,M,27,176,77,Portugal,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",NA
+Luza vila Borges Carvalho,F,33,182,79,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Miguel ngelo Henriques Carvalho,M,21,185,72,Portugal,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+David Carver,M,28,183,68,Mauritius,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Mara Casado Gonzlez,F,30,167,63,Spain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Yennifer Frank Casaas Hernndez,M,37,187,117,Spain,2016 Summer,Athletics,Athletics Men's Discus Throw,NA
+Gilda Isabelis Casanova Aguilera,F,20,165,54,Cuba,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Helena Casas Roige,F,28,163,63,Spain,2016 Summer,Cycling,Cycling Women's Sprint,NA
+Helena Casas Roige,F,28,163,63,Spain,2016 Summer,Cycling,Cycling Women's Keirin,NA
+Helena Casas Roige,F,28,163,63,Spain,2016 Summer,Cycling,Cycling Women's Team Sprint,NA
+lex Casasayas Carles,M,28,183,78,Spain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Beln Adaluz Casetta,F,21,163,52,Argentina,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Miriam Casillas Garca,F,24,164,52,Spain,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Charlotte Caslick,F,21,172,65,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Gold
+Andrea Cassar,M,32,193,93,Italy,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Andrea Cassar,M,32,193,93,Italy,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Matteo Castaldo,M,30,188,86,Italy,2016 Summer,Rowing,Rowing Men's Coxless Fours,Bronze
+Jorge Castelblanco,M,28,169,58,Panama,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Asnage Castelly,M,38,182,74,Haiti,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Freestyle",NA
+Yael Castiglione,F,30,184,75,Argentina,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Arianna Castiglioni,F,18,167,55,Italy,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Arianna Castiglioni,F,18,167,55,Italy,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Claudio Castilla Ruz,M,33,173,66,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Claudio Castilla Ruz,M,33,173,66,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Carles Castillejo Salvador,M,37,165,61,Spain,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Carolina Castillo Hidalgo,F,25,157,48,Colombia,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Julio Csar Castillo Torres,M,28,183,91,Ecuador,2016 Summer,Boxing,Boxing Men's Heavyweight,NA
+Yalennis Castillo Ramrez,F,30,174,78,Cuba,2016 Summer,Judo,Judo Women's Half-Heavyweight,NA
+Kristi Castlin,F,28,170,60,United States,2016 Summer,Athletics,Athletics Women's 100 metres Hurdles,Bronze
+ngela Melania Castro Chirivechz,F,23,160,54,Bolivia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Lilian Castro,F,29,164,63,El Salvador,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Lus Joel Castro Rivera,M,25,198,73,Puerto Rico,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Patricia Castro Ortega,F,23,178,66,Spain,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Patricia Castro Ortega,F,23,178,66,Spain,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Patricia Castro Ortega,F,23,178,66,Spain,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Simona Castro Lazo,F,27,160,54,Chile,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Simona Castro Lazo,F,27,160,54,Chile,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Simona Castro Lazo,F,27,160,54,Chile,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Simona Castro Lazo,F,27,160,54,Chile,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Jonathan Castroviejo Nicols,M,29,172,64,Spain,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Jonathan Castroviejo Nicols,M,29,172,64,Spain,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Tamika Devonne Catchings,F,37,185,77,United States,2016 Summer,Basketball,Basketball Women's Basketball,Gold
+"Stephanie-Elise ""Steph"" Catley",F,22,171,58,Australia,2016 Summer,Football,Football Women's Football,NA
+Kelly Catlin,F,20,168,63,United States,2016 Summer,Cycling,Cycling Women's Team Pursuit,Silver
+"Nicholas Andrew ""Nick"" Catlin",M,27,175,76,Great Britain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Roxroy Cato,M,28,183,76,Jamaica,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Camilla Cattaneo,F,26,173,54,Italy,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Jssica Bruin Cavalheiro,F,25,164,60,Brazil,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Martina Cavallero,F,26,163,58,Argentina,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Mark Simon Cavendish,M,31,175,70,Great Britain,2016 Summer,Cycling,Cycling Men's Omnium,Silver
+Rachel Elizabeth Cawthorn,F,27,177,70,Great Britain,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 500 metres",NA
+Rachel Elizabeth Cawthorn,F,27,177,70,Great Britain,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",NA
+Magda Alfredo Cazanga,F,25,172,54,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Rodolfo Eduardo Cazaubn Rincn,M,26,178,68,Mexico,2016 Summer,Golf,Golf Men's Individual,NA
+Saa ao,F,27,178,72,Serbia,2016 Summer,Basketball,Basketball Women's Basketball,Bronze
+Pedro Francisco Ceballos Fuentes,M,25,180,86,Venezuela,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Freestyle",NA
+Nicolai Ceban,M,30,186,96,Moldova,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Seluk ebi,M,34,169,76,Turkey,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",NA
+Alicia Cebrin Martnez de Lagos,F,33,168,68,Spain,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Elena Cecchini,F,24,168,55,Italy,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Serghei Cechir,M,25,172,72,Moldova,2016 Summer,Weightlifting,Weightlifting Men's Lightweight,NA
+Machel Cedenio,M,20,183,70,Trinidad and Tobago,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Machel Cedenio,M,20,183,70,Trinidad and Tobago,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Camilla Cedercreutz,F,23,167,66,Finland,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Andrea del Rosario Cedrn Rodrguez,F,22,169,62,Peru,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Benjmin Ceiner,M,24,197,94,Hungary,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 1,000 metres",NA
+Benjmin Ceiner,M,24,197,94,Hungary,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+"Alexander ""Alex"" ejka",M,45,173,77,Germany,2016 Summer,Golf,Golf Men's Individual,NA
+Jeena elnova-Prokopuka,F,39,168,52,Latvia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Martina Centofanti,F,18,170,47,Italy,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Nadia Centoni,F,35,182,63,Italy,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+"Matthew Gerald ""Matt"" Centrowitz, Jr.",M,26,176,65,United States,2016 Summer,Athletics,"Athletics Men's 1,500 metres",Gold
+Vernica Cepede Royg,F,24,163,66,Paraguay,2016 Summer,Tennis,Tennis Women's Singles,NA
+Mihajlo eprkalo,M,17,172,74,Bosnia and Herzegovina,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Tales Rocha Cerdeira,M,29,182,77,Brazil,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Larisa Ceri,F,25,176,110,Bosnia and Herzegovina,2016 Summer,Judo,Judo Women's Heavyweight,NA
+Marua ernjul,F,24,177,56,Slovenia,2016 Summer,Athletics,Athletics Women's High Jump,NA
+Giovanni Cernogoraz,M,33,186,90,Croatia,2016 Summer,Shooting,Shooting Men's Trap,NA
+Linda Cerruti,F,22,173,56,Italy,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Linda Cerruti,F,22,173,56,Italy,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Isadora Cerullo,F,25,158,58,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Yennifer Mariana Csar Salazar,F,27,159,57,Venezuela,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Claudia Cesarini,F,29,177,60,Italy,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,NA
+Avtandil Ch'rik'ishvili,M,25,182,80,Georgia,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Farid Chaal,M,22,196,80,Algeria,2016 Summer,Football,Football Men's Football,NA
+Wiktor Chabel,M,30,192,98,Poland,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Rosa Alba Chacha Chacha,F,33,155,48,Ecuador,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Adrin Chacn Muoz,M,27,187,90,Cuba,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Leonardo Chacn Corrales,M,32,179,65,Costa Rica,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Abdelkader Chadi,M,29,175,60,Algeria,2016 Summer,Boxing,Boxing Men's Light-Welterweight,NA
+Louisa Chafee,F,24,165,57,United States,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Chai Biao,M,25,186,80,China-2,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Sheila Chajira Kavugwe,F,22,165,73,Kenya,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Hassen Al-Chaktami,M,27,180,91,Tunisia,2016 Summer,Boxing,Boxing Men's Heavyweight,NA
+Davit Gochayevich Chakvetadze,M,23,174,85,Russia,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Greco-Roman",Gold
+Kyle Chalmers,M,18,193,90,Australia,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,Gold
+Kyle Chalmers,M,18,193,90,Australia,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,Bronze
+Kyle Chalmers,M,18,193,90,Australia,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,Bronze
+Mussa Chamaune,M,23,172,66,Mozambique,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 1,000 metres",NA
+Mussa Chamaune,M,23,172,66,Mozambique,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, 1,000 metres",NA
+Peter Chambers,M,26,186,72,Great Britain,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,NA
+Richard Scott Chambers,M,31,183,74,Great Britain,2016 Summer,Rowing,Rowing Men's Lightweight Double Sculls,NA
+Frank Chamizo Marquez,M,24,172,65,Italy,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Freestyle",Bronze
+Miles Cleveland Chamley-Watson,M,26,193,80,United States,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Miles Cleveland Chamley-Watson,M,26,193,80,United States,2016 Summer,Fencing,"Fencing Men's Foil, Team",Bronze
+Ludovic Chammartin,M,31,168,60,Switzerland,2016 Summer,Judo,Judo Men's Extra-Lightweight,NA
+Victria Chamorro,F,20,176,78,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Simeon Chamov,M,25,180,69,Bulgaria,2016 Summer,Boxing,Boxing Men's Welterweight,NA
+Chan Chun Hing,M,35,170,70,Hong Kong,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Chan Hao-Ching,F,22,175,60,Chinese Taipei,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Chan Ming Tai,M,21,175,66,Hong Kong,2016 Summer,Athletics,Athletics Men's Long Jump,NA
+Chan Peng Soon,M,28,175,68,Malaysia,2016 Summer,Badminton,Badminton Mixed Doubles,Silver
+"Zhi Cheng ""Tiffany"" Chan",F,22,160,52,Hong Kong,2016 Summer,Golf,Golf Women's Individual,NA
+Chan Yung-Jan,F,26,170,60,Chinese Taipei,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Dutee Chand,F,20,160,50,India,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Nickel Nishal Chand,M,21,167,60,Fiji,2016 Summer,Football,Football Men's Football,NA
+Apurvi Singh Chandela,F,23,157,54,India,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Chang Hao,M,25,173,72,Chinese Taipei,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+Chang Hye-Jin,F,29,158,50,South Korea,2016 Summer,Archery,Archery Women's Individual,Gold
+Chang Hye-Jin,F,29,158,50,South Korea,2016 Summer,Archery,Archery Women's Team,Gold
+Chang Ye-Na,F,26,172,61,South Korea-2,2016 Summer,Badminton,Badminton Women's Doubles,NA
+Hassan Chani,M,28,170,60,Bahrain,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Natthanan Chankrajang,F,30,166,57,Thailand,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Kamolwan Chanyim,F,20,175,65,Thailand,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Allysha Chapman,F,27,160,56,Canada,2016 Summer,Football,Football Women's Football,Bronze
+David Chapman,M,51,165,72,Australia,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+Germain Louis Marcel Chardin,M,33,195,90,France,2016 Summer,Rowing,Rowing Men's Coxless Pairs,NA
+Karen Charles (Cope-),F,30,173,60,Costa Rica,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Lus Enrique Charles,M,17,183,65,Dominican Republic,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Tina Alexandria Charles,F,27,193,88,United States,2016 Summer,Basketball,Basketball Women's Basketball,Gold
+Cdric Charlier,M,28,181,81,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+"Samantha ""Sam"" Charlton",F,24,174,66,New Zealand,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Olfa Al-Charni,F,36,176,65,Tunisia,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Olfa Al-Charni,F,36,176,65,Tunisia,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Andrew Charter,M,29,182,87,Australia,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Chanice Chase-Taylor,F,22,173,61,Canada,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Andreas Chasikos,M,32,175,70,Cyprus,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Chau Hoi Wah,F,30,165,61,Hong Kong,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+Matthew Chau,M,21,185,77,Australia,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Johan Esteban Chaves Rubio,M,26,164,54,Colombia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Arturo Chvez Korfiatis,M,26,190,76,Peru,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Elisabeth Chvez Hernndez,F,25,192,81,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+Kevin Alejandro Chvez Banda,M,24,170,70,Australia,2016 Summer,Diving,Diving Men's Springboard,NA
+Viviana Micaela Chvez,F,29,164,52,Argentina,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Shiv Sankar Prasad Chawrasia,M,38,165,67,India,2016 Summer,Golf,Golf Men's Individual,NA
+Viktoriya Vladimirovna Chayka,F,35,164,50,Belarus,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Viktoriya Vladimirovna Chayka,F,35,164,50,Belarus,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Geoffrey Robin Cheah,M,25,188,70,Hong Kong,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Yuriy Volodymyrovych Cheban,M,30,185,93,Ukraine,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 200 metres",Gold
+Radhouane Chebbi,M,30,184,125,Tunisia,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Freestyle",NA
+Winny Chebet,F,25,152,48,Kenya,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Artyom Nikolayevich Chebotaryov,M,27,184,75,Russia,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Nihel Cheikh Rouhou,F,29,164,78,Tunisia,2016 Summer,Judo,Judo Women's Heavyweight,NA
+Juliet Chekwel,F,26,NA,NA,Uganda,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Juliet Chekwel,F,26,NA,NA,Uganda,2016 Summer,Athletics,"Athletics Women's 10,000 metres",NA
+Paul Kipkemboi Chelimo,M,25,175,57,United States,2016 Summer,Athletics,"Athletics Men's 5,000 metres",Silver
+Rose Chelimo,F,27,NA,NA,Bahrain,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Lonah Korlima Chemtai,F,27,165,52,Israel,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Peruth Chemutai,F,17,NA,NA,Uganda,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Chen Aisen,M,20,168,60,China,2016 Summer,Diving,Diving Men's Platform,Gold
+Chen Aisen,M,20,168,60,China,2016 Summer,Diving,Diving Men's Synchronized Platform,Gold
+Chen Chieh,M,24,182,73,Chinese Taipei,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Chen Chien-An,M,25,170,72,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Chen Chien-An,M,25,170,72,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Chen Ding,M,23,175,62,China,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Chen Fang,F,32,171,60,China,2016 Summer,Shooting,Shooting Women's Trap,NA
+Feng Chen,M,22,170,65,Singapore,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Chen Haiwei,M,21,188,78,China,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Chen Haiwei,M,21,188,78,China,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Chen Jie,F,21,177,65,China,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,NA
+Chen Lijun,M,23,162,65,China,2016 Summer,Weightlifting,Weightlifting Men's Featherweight,NA
+Chen Long,M,27,188,81,China,2016 Summer,Badminton,Badminton Men's Singles,Gold
+Chen Nan,F,33,195,94,China,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Chen Nien-Chin,F,19,169,75,Chinese Taipei,2016 Summer,Boxing,Boxing Women's Middleweight,NA
+Chen Peina,F,27,172,63,China,2016 Summer,Sailing,Sailing Women's Windsurfer,Silver
+Chen Qian,F,29,163,54,China,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,NA
+Chen Ruolin,F,23,160,47,China,2016 Summer,Diving,Diving Women's Synchronized Platform,Gold
+Chen Shih-Chieh,M,26,190,150,Chinese Taipei,2016 Summer,Weightlifting,Weightlifting Men's Super-Heavyweight,NA
+Chen Szu-Yu,F,23,162,58,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Chen Szu-Yu,F,23,162,58,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Women's Team,NA
+Chen Wei-Ling,F,34,149,47,Chinese Taipei,2016 Summer,Weightlifting,Weightlifting Women's Flyweight,NA
+Chen Wen-Ling,F,21,175,69,Chinese Taipei,2016 Summer,Wrestling,"Wrestling Women's Light-Heavyweight, Freestyle",NA
+"Hsuan-Yu ""Wendy"" Chen",F,23,167,56,Australia,2016 Summer,Badminton,Badminton Women's Singles,NA
+Chen Xiaojia,F,28,182,68,China,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Chen Xinyi,F,18,177,60,China,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+Chen Yang,F,25,180,97,China,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Chen Ying,F,38,164,67,China,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Chen Yu-Hsuan,F,23,157,50,Chinese Taipei,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Kynan Darius Chenai,M,25,200,85,India,2016 Summer,Shooting,Shooting Men's Trap,NA
+"Li Mei ""Camille Lily"" Cheng",F,23,178,65,Hong Kong,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+"Li Mei ""Camille Lily"" Cheng",F,23,178,65,Hong Kong,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+"Li Mei ""Camille Lily"" Cheng",F,23,178,65,Hong Kong,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+"Li Mei ""Camille Lily"" Cheng",F,23,178,65,Hong Kong,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+"Xinru ""Colin"" Cheng",M,26,175,80,Singapore,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Cheng I-Ching,F,24,162,52,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Cheng I-Ching,F,24,162,52,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Women's Team,NA
+"Chun Leung ""Michael"" Cheng",M,22,182,74,Hong Kong,2016 Summer,Sailing,Sailing Men's Windsurfer,NA
+Cheng Xunzhao,M,25,185,90,China,2016 Summer,Judo,Judo Men's Middleweight,Bronze
+Cheon Eun-Bi,F,24,165,59,South Korea,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Cheong Jun Hoong,F,26,150,48,Malaysia,2016 Summer,Diving,Diving Women's Springboard,NA
+Cheong Jun Hoong,F,26,150,48,Malaysia,2016 Summer,Diving,Diving Women's Synchronized Springboard,NA
+Cheong Jun Hoong,F,26,150,48,Malaysia,2016 Summer,Diving,Diving Women's Synchronized Platform,Silver
+Beatrice Chepkoech Sitonik,F,25,170,54,Kenya,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Nancy Chepkwemoi,F,22,NA,47,Kenya,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Joshua Kiprui Cheptegei,M,19,NA,NA,Uganda,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Joshua Kiprui Cheptegei,M,19,NA,NA,Uganda,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Mariana Cherdivar-Eanu,F,23,160,62,Moldova,2016 Summer,Wrestling,"Wrestling Women's Lightweight, Freestyle",NA
+Oreoluwa Cherebin,F,18,150,54,Grenada,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+Aleksey Borisovich Cheremisinov,M,31,183,75,Russia,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Aleksey Borisovich Cheremisinov,M,31,183,75,Russia,2016 Summer,Fencing,"Fencing Men's Foil, Team",Gold
+Ilya Vladimirovich Chergeyko,M,23,179,81,Belarus,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Ilya Vladimirovich Chergeyko,M,23,179,81,Belarus,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Imne Ouneissa Cherif Sahraoui,F,20,165,64,Algeria,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Alla Kostiantynivna Cherkasova,F,27,165,75,Ukraine,2016 Summer,Wrestling,"Wrestling Women's Heavyweight, Freestyle",NA
+Oleksandr Stepanovych Chernetskiy,M,32,195,130,Ukraine,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Greco-Roman",NA
+Sergey Vitalyevich Chernetsky,M,26,176,63,Russia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Maryna Mykolavna Cherniak,F,28,162,48,Ukraine,2016 Summer,Judo,Judo Women's Extra-Lightweight,NA
+Abraham Naibei Cheroben,M,23,176,60,Bahrain,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Mercy Cherono Koech,F,25,NA,51,Kenya,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Emilee Cherry,F,23,168,70,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Gold
+Vivian Jepkemoi Cheruiyot,F,32,153,40,Kenya,2016 Summer,Athletics,"Athletics Women's 5,000 metres",Gold
+Vivian Jepkemoi Cheruiyot,F,32,153,40,Kenya,2016 Summer,Athletics,"Athletics Women's 10,000 metres",Silver
+Nelson Kipkosgei Cherutich,M,23,170,60,Bahrain,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Stella Chesang,F,19,NA,NA,Uganda,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Silvano Chesani,M,28,190,75,Italy,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Andrew Chetcuti,M,23,177,72,Malta,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+William Chetcuti,M,31,180,93,Malta,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+"Ka Long ""Edgar"" Cheung",M,19,181,68,Hong Kong,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Cheung King Lok,M,25,172,77,Hong Kong,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Phillip Hung Chew,M,22,173,91,United States,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+Phillip Hung Chew,M,22,173,91,United States,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Danny Chia,M,43,170,75,Malaysia,2016 Summer,Golf,Golf Men's Individual,NA
+Chiang Hung-Chieh,M,27,180,70,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Izabella Maizza Chiappini,F,20,170,59,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Andrea Chiarabini,M,21,179,70,Italy,2016 Summer,Diving,Diving Men's Springboard,NA
+Andrea Chiarabini,M,21,179,70,Italy,2016 Summer,Diving,Diving Men's Synchronized Springboard,NA
+Germn Pablo Chiaraviglio Ermcora,M,29,195,84,Argentina,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Charles Koshiro Chibana,M,26,163,66,Brazil,2016 Summer,Judo,Judo Men's Half-Lightweight,NA
+Eunice Chibanda,F,23,163,61,Zimbabwe,2016 Summer,Football,Football Women's Football,NA
+Kseniya Eduardovna Chibisova,F,28,186,78,Russia,2016 Summer,Judo,Judo Women's Heavyweight,NA
+Jennifer Dugwen Chieng,F,30,161,60,Federated States of Micronesia,2016 Summer,Boxing,Boxing Women's Lightweight,NA
+James Nyang Chiengjiek,M,24,179,59,Refugee Olympic Athletes,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Marcelo Chierighini,M,25,190,86,Brazil,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Marcelo Chierighini,M,25,190,86,Brazil,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Marcelo Chierighini,M,25,190,86,Brazil,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Maria Benedicta Chigbolu,F,27,172,55,Italy,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Maria Benedicta Chigbolu,F,27,172,55,Italy,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Vlada Aleksandrovna Chigiryova,F,21,162,46,Russia,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,Gold
+Pavel Chihun Camayo,M,30,170,70,Peru,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Darya Yaroslavovna Chikunova,F,17,177,59,Russia,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Simon Child,M,28,186,80,New Zealand,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Eilidh Child-Doyle,F,29,170,60,Great Britain,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Eilidh Child-Doyle,F,29,170,60,Great Britain,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,Bronze
+Gayane Chiloyan,F,15,164,54,Armenia,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Svetlana Mikhaylovna Chimrova,F,20,173,61,Russia,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+Svetlana Mikhaylovna Chimrova,F,20,173,61,Russia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Chatuphum Chinnawong,M,23,167,77,Thailand,2016 Summer,Weightlifting,Weightlifting Men's Middleweight,NA
+Jordan Chipangama,M,27,173,53,Zambia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Laura Chiper,F,26,173,65,Romania,2016 Summer,Handball,Handball Women's Handball,NA
+Mavis Chirandu,F,21,157,53,Zimbabwe,2016 Summer,Football,Football Women's Football,NA
+Cristina Chirichella,F,22,195,73,Italy,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Tatiana Chica,F,21,175,60,Moldova,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Kefasi Chitsala,M,22,170,63,Malawi,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Andreea Stefania Chiu,F,28,157,52,Romania,2016 Summer,Judo,Judo Women's Half-Lightweight,NA
+Chiu Hin Chun,M,21,176,73,Hong Kong,2016 Summer,Rowing,Rowing Men's Lightweight Double Sculls,NA
+Fbio Rocha Chiuffa,M,27,185,85,Brazil,2016 Summer,Handball,Handball Men's Handball,NA
+Giorgi Chkheidze,M,18,178,105,Georgia,2016 Summer,Weightlifting,Weightlifting Men's Heavyweight,NA
+Cho Gu-Ham,M,24,178,100,South Korea,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Cho Gwang-Hee,M,22,182,92,South Korea,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+Cho Gwang-Hee,M,22,182,92,South Korea,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+Cho Hye-Jin,F,21,159,56,South Korea,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Mahama Abdoufatah Cho,M,26,196,100,Great Britain,2016 Summer,Taekwondo,Taekwondo Men's Heavyweight,NA
+Cristian Andrs Chocho Len,M,32,170,66,Ecuador,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Cristian Andrs Chocho Len,M,32,170,66,Ecuador,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Choe Byeong-Kwang,M,25,185,73,South Korea,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Choe Hyo-Sim,F,22,159,63,North Korea,2016 Summer,Weightlifting,Weightlifting Women's Middleweight,Silver
+Choe Jon-Wi,M,23,170,77,North Korea,2016 Summer,Weightlifting,Weightlifting Men's Middleweight,NA
+Choi Eun-Sook,F,30,169,59,South Korea,2016 Summer,Fencing,"Fencing Women's epee, Team",NA
+Choi Gyu-Wung,M,26,181,75,South Korea,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Choi In-Jeong,F,26,174,59,South Korea,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Choi In-Jeong,F,26,174,59,South Korea,2016 Summer,Fencing,"Fencing Women's epee, Team",NA
+Choi Kyu-Baek,M,22,188,77,South Korea,2016 Summer,Football,Football Men's Football,NA
+Choi Mi-Sun,F,20,168,53,South Korea,2016 Summer,Archery,Archery Women's Individual,NA
+Choi Mi-Sun,F,20,168,53,South Korea,2016 Summer,Archery,Archery Women's Team,Gold
+Choi Min-Kyu,M,23,184,84,South Korea,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+Choi Su-Min,F,26,177,64,South Korea,2016 Summer,Handball,Handball Women's Handball,NA
+Sra Cholnoky,F,27,165,66,Hungary,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Dimitrios Chondrokoukis,M,28,194,74,Cyprus,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Arli Chontey,M,24,150,56,Kazakhstan,2016 Summer,Weightlifting,Weightlifting Men's Bantamweight,NA
+Bei Fen Jovina Choo,F,26,164,57,Singapore,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+"Nyuk Lian ""Leanne"" Choo",F,25,167,58,Australia,2016 Summer,Badminton,Badminton Mixed Doubles,NA
+"Joseph Tzen Zhun ""Joe"" Choong",M,21,186,78,Great Britain,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Chou Tien-Chen,M,26,180,78,Chinese Taipei,2016 Summer,Badminton,Badminton Men's Singles,NA
+Marouan Chouiref,M,26,195,109,Tunisia,2016 Summer,Handball,Handball Men's Handball,NA
+Alexander Choupenitch,M,22,196,89,Czech Republic,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Maialen Chourraut Yurramendi,F,33,161,55,Spain,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, Slalom",Gold
+Chov Sotheara,F,32,155,48,Cambodia,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Felice Chow,F,39,175,70,Trinidad and Tobago,2016 Summer,Rowing,Rowing Women's Single Sculls,NA
+Margaux Emmanuelle Chrtien,F,23,172,61,France,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Nina Christen,F,22,160,57,Switzerland,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Nina Christen,F,22,160,57,Switzerland,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Simone Tetsche Christensen,F,22,170,68,Denmark,2016 Summer,Cycling,Cycling Women's BMX,NA
+Micah Makanamaikalani Christenson,M,23,198,86,United States,2016 Summer,Volleyball,Volleyball Men's Volleyball,Bronze
+Henrik Christiansen,M,19,191,NA,Norway,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Henrik Christiansen,M,19,191,NA,Norway,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Henrik Christiansen,M,19,191,NA,Norway,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Mads Christiansen,M,30,197,93,Denmark,2016 Summer,Handball,Handball Men's Handball,Gold
+Max Christiansen,M,19,187,84,Germany,2016 Summer,Football,Football Men's Football,Silver
+Antri Christoforou,F,24,166,53,Cyprus,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Kate Christowitz,F,25,184,76,South Africa,2016 Summer,Rowing,Rowing Women's Coxless Pairs,NA
+Chuang Chia-Chia,F,27,179,65,Chinese Taipei,2016 Summer,Taekwondo,Taekwondo Women's Welterweight,NA
+Chuang Chih-Yuan,M,35,166,60,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Chuang Chih-Yuan,M,35,166,60,Chinese Taipei,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Dmytro Vitaliyovych Chumak,M,26,171,95,Ukraine,2016 Summer,Weightlifting,Weightlifting Men's Middle-Heavyweight,NA
+Chun In-Gee,F,21,175,70,South Korea,2016 Summer,Golf,Golf Women's Individual,NA
+Anton Mikhaylovich Chupkov,M,19,188,71,Russia,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,Bronze
+Anton Mikhaylovich Chupkov,M,19,188,71,Russia,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Andrey Viktorovich Churilo,M,23,189,74,Belarus,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Oksana Aleksandrovna Chusovitina,F,41,153,43,Uzbekistan,2016 Summer,Gymnastics,Gymnastics Women's Horse Vault,NA
+Oksana Aleksandrovna Chusovitina,F,41,153,43,Uzbekistan,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Monika Ciaciuch,F,24,182,74,Poland,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,Bronze
+Hlna Ciak,F,26,197,89,France,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Angelika Cichocka,F,28,170,56,Poland,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Angelika Cichocka,F,28,170,56,Poland,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Jeanine Cicognini,F,29,170,73,Italy,2016 Summer,Badminton,Badminton Women's Singles,NA
+Aina Cid Centelles,F,21,170,60,Spain,2016 Summer,Rowing,Rowing Women's Coxless Pairs,NA
+Javier Cienfuegos Pinilla,M,26,187,110,Spain,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Carlota Ciganda Machiena,F,26,173,68,Spain,2016 Summer,Golf,Golf Women's Individual,NA
+Marin ili,M,27,198,82,Croatia,2016 Summer,Tennis,Tennis Men's Singles,NA
+Marin ili,M,27,198,82,Croatia,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Ate nar,M,30,172,72,Turkey,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Deniz nar,M,31,172,65,Turkey,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Darko Cingesar,M,26,187,93,Slovenia,2016 Summer,Handball,Handball Men's Handball,NA
+Mathilde Cini,F,21,166,62,France,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Ondej Cink,M,25,178,68,Czech Republic,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Jeyvier Jess Cintrn Ocasio,M,21,171,52,Puerto Rico,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+"Christopher ""Chris"" Ciriello",M,30,182,83,Australia,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Mikls Cirjenics,M,26,190,104,Hungary,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Elena Daniela Crlan,F,35,164,47,Romania,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Carlos Ernesto Cisneros Barajas,M,22,175,67,Mexico,2016 Summer,Football,Football Men's Football,NA
+Cheick Sallah Ciss Junior,M,22,186,80,Cote d'Ivoire,2016 Summer,Taekwondo,Taekwondo Men's Welterweight,Gold
+Souleymane Diop Cissokho,M,25,179,69,France,2016 Summer,Boxing,Boxing Men's Welterweight,Bronze
+Merven Clair,M,23,178,75,Mauritius,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Sandie Clair,F,28,160,60,France,2016 Summer,Cycling,Cycling Women's Sprint,NA
+Sandie Clair,F,28,160,60,France,2016 Summer,Cycling,Cycling Women's Keirin,NA
+Sandie Clair,F,28,160,60,France,2016 Summer,Cycling,Cycling Women's Team Sprint,NA
+"Edward ""Ed"" Clancy",M,31,185,79,Great Britain,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",Gold
+Taliqua Clancy,F,24,184,68,Australia-1,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Francesca Clapcich,F,28,177,68,Italy,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Cameron Clark,M,23,185,85,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Katie Lauren Clark,F,22,168,52,Great Britain,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+"Caroline Archer ""KK"" Clark",F,26,188,72,United States,2016 Summer,Water Polo,Water Polo Women's Water Polo,Gold
+Milly Clark,F,27,NA,NA,Australia,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Saskia Clark,F,36,176,68,Great Britain,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,Gold
+Allistar Clarke,M,25,187,71,Saint Kitts and Nevis,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+"Joseph ""Joe"" Clarke",M,23,182,76,Great Britain,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",Gold
+Kendra Clarke,F,19,167,56,Canada,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Lanece Clarke,F,28,170,52,Bahamas,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Charles Lawrence Somerset Clarke,M,26,187,77,Great Britain,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Simon Clarke,M,30,175,64,Australia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Felipe Claro Santa'Ana Silva,M,30,172,83,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Perrine Clauzel,F,22,155,47,France,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Vctor Claver Arocas,M,27,206,107,Spain,2016 Summer,Basketball,Basketball Men's Basketball,Bronze
+Carlos Eduardo Claverie Borgiani,M,19,190,68,Venezuela,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Carlos Eduardo Claverie Borgiani,M,19,190,68,Venezuela,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+ngela Corina Clavijo Silva,F,22,163,59,Colombia,2016 Summer,Football,Football Women's Football,NA
+Grace Claxton,F,22,NA,NA,Puerto Rico,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Jane-Anne Claxton,F,23,169,60,Australia,2016 Summer,Hockey,Hockey Women's Hockey,NA
+"William Bundu ""Will"" Claye",M,25,181,72,United States,2016 Summer,Athletics,Athletics Men's Triple Jump,Silver
+"Laurent Clayton, Jr.",M,26,196,127,United States Virgin Islands,2016 Summer,Boxing,Boxing Men's Super-Heavyweight,NA
+Jacob Clear,M,31,185,86,Australia,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Jennifer Cleary,F,23,175,71,Australia,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,NA
+"Jonathan ""Jono"" Clegg",M,27,186,72,Great Britain,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,NA
+Kerron Stephon Clement,M,30,188,86,United States,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,Gold
+Kyle Clemons,M,25,180,74,United States,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,Gold
+Damien Cler,M,32,185,95,France,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Mick Clohisey,M,30,180,64,Ireland,2016 Summer,Athletics,Athletics Men's Marathon,NA
+lodie Pascaline Clouvel,F,27,182,69,France,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,Silver
+Cavid lbiyev,M,24,170,56,Azerbaijan,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Georgia Amy Coates,F,17,170,54,Great Britain,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Georgia Amy Coates,F,17,170,54,Great Britain,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Georgia Amy Coates,F,17,170,54,Great Britain,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Emma Jane Coburn,F,25,173,54,United States,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",Bronze
+Ryan Andrew Cochrane,M,27,192,80,Canada,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Ryan Andrew Cochrane,M,27,192,80,Canada,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Ryan Cochrane,M,33,178,78,Canada,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+Marius Iulian Cocioran,M,33,173,64,Romania,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Sophie Cocks,F,22,172,62,New Zealand,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Piero Codia,M,26,190,80,Italy,2016 Summer,Swimming,Swimming Men's 100 metres Butterfly,NA
+Piero Codia,M,26,190,80,Italy,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Giovanni Orlando Codrington,M,28,177,84,Netherlands,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Jordan Coelho,M,24,183,75,France,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Willem Coertzen,M,33,186,79,South Africa,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Rivaldo Roberto Genino Coetzee,M,19,183,73,South Africa,2016 Summer,Football,Football Men's Football,NA
+Corey Cogdell-Unrein,F,29,173,70,United States,2016 Summer,Shooting,Shooting Women's Trap,Bronze
+Roxana Gabriela Cogianu,F,29,180,72,Romania,2016 Summer,Rowing,Rowing Women's Coxed Eights,Bronze
+Gil Cohen,F,24,170,62,Israel,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Gili Cohen,F,25,160,52,Israel,2016 Summer,Judo,Judo Women's Half-Lightweight,NA
+Adelina Maria Cojocariu-Bogus,F,27,186,75,Romania,2016 Summer,Rowing,Rowing Women's Coxed Eights,Bronze
+Massimo Colaci,M,31,180,75,Italy,2016 Summer,Volleyball,Volleyball Men's Volleyball,Silver
+Thibault Colard,M,24,187,70,France,2016 Summer,Rowing,Rowing Men's Lightweight Coxless Fours,Bronze
+"Charles ""Charlie"" Cole",M,30,194,90,United States,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Christian Coleman,M,20,175,72,United States,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Michelle Elizabeth Coleman,F,22,186,74,Sweden,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Michelle Elizabeth Coleman,F,22,186,74,Sweden,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Michelle Elizabeth Coleman,F,22,186,74,Sweden,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Michelle Elizabeth Coleman,F,22,186,74,Sweden,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Ndia Gomes Colhado,F,27,194,88,Brazil,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Williams Collazo Gutirrez,M,29,172,71,Cuba,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Latario Collie-Minns,M,22,173,64,Bahamas,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+John Collins,M,27,192,95,Great Britain,2016 Summer,Rowing,Rowing Men's Double Sculls,NA
+Kim Collins,M,40,180,77,Saint Kitts and Nevis,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Kim Collins,M,40,180,77,Saint Kitts and Nevis,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Nstor Enrique Colmenares Uzcategui,M,28,203,110,Venezuela,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Carlos Coloma Nicols,M,34,171,65,Spain,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",Bronze
+Nestor Landag Colonia,M,24,158,59,Philippines,2016 Summer,Weightlifting,Weightlifting Men's Bantamweight,NA
+Diego Alberto Colorado Agudelo,M,42,171,57,Colombia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Nicolas Colsaerts,M,33,188,78,Belgium,2016 Summer,Golf,Golf Men's Individual,NA
+Brbara Roco Comba,F,29,180,100,Argentina,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Sbastien Combot,M,29,169,64,France,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Gloria Comerma Broto,F,29,168,64,Spain,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Aude Compan,F,23,173,67,France,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Benjamin Compaor,M,28,189,83,France,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Jhennifer Alves da Conceio,F,19,162,53,Brazil,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Robson Donato Conceio,M,27,171,57,Brazil,2016 Summer,Boxing,Boxing Men's Lightweight,Gold
+Javier Octavio Concepcin Rojas,M,18,200,84,Cuba,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+David John Condon,M,25,180,79,Great Britain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Santo Condorelli,M,21,188,88,Canada,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Santo Condorelli,M,21,188,88,Canada,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Santo Condorelli,M,21,188,88,Canada,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Santo Condorelli,M,21,188,88,Canada,2016 Summer,Swimming,Swimming Men's 100 metres Butterfly,NA
+Muriel Coneo Paredes,F,29,160,50,Colombia,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Rick Yves Confiance,M,22,165,62,Seychelles,2016 Summer,Weightlifting,Weightlifting Men's Featherweight,NA
+"John ""Jack"" Conger",M,21,193,80,United States,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,Gold
+Dorian Coninx,M,22,181,70,France,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Michael John Conlan,M,24,170,56,Ireland,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Alyssa Conley,F,25,176,63,South Africa,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Alyssa Conley,F,25,176,63,South Africa,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+"Kimberley Frances ""Kim"" Conley",F,30,161,49,United States,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Breege Connolly,F,38,163,54,Ireland,2016 Summer,Athletics,Athletics Women's Marathon,NA
+"James ""Jimmy"" Connor",M,21,183,68,Australia,2016 Summer,Diving,Diving Men's Platform,NA
+Simone Consonni,M,21,165,60,Italy,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",NA
+Patrick Constable,M,21,183,95,Australia,2016 Summer,Cycling,Cycling Men's Sprint,NA
+Patrick Constable,M,21,183,95,Australia,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Patrick Constable,M,21,183,95,Australia,2016 Summer,Cycling,Cycling Men's Team Sprint,NA
+Facundo Conte,M,26,197,88,Argentina,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Giulia Conti,F,28,173,62,Italy,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Edgar Jess Contreras Triana,M,24,178,67,Venezuela,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,NA
+Yidiel Islay Contreras Garca,M,23,180,74,Spain,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Yudelquis Maridalia Contreras,F,30,158,58,Dominican Republic,2016 Summer,Weightlifting,Weightlifting Women's Lightweight,NA
+Sally Conway,F,29,167,70,Great Britain,2016 Summer,Judo,Judo Women's Middleweight,Bronze
+Charles Albert Shone Conwell,M,18,175,75,United States,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Aaron Arthur Cook,M,25,183,80,Moldova,2016 Summer,Taekwondo,Taekwondo Men's Welterweight,NA
+Kassidy Leigh Cook,F,21,163,57,United States,2016 Summer,Diving,Diving Women's Springboard,NA
+Tamsin Cook,F,17,170,61,Australia,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Tamsin Cook,F,17,170,61,Australia,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,NA
+Tamsin Cook,F,17,170,61,Australia,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,Silver
+"James ""Jamie"" Cooke",M,25,185,74,Great Britain,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Reid Coolsaet,M,37,173,62,Canada,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Anuradha Indrajith Cooray,M,38,178,58,Sri Lanka,2016 Summer,Athletics,Athletics Men's Marathon,NA
+"Katherine Sarah ""Kat"" Copeland",F,25,172,58,Great Britain,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Leslie Arthur Copeland,M,28,183,102,Fiji,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+Yasmani Copello Escobar,M,29,191,85,Turkey,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,Bronze
+Aye Cora,F,23,175,69,Turkey,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Kevin Cordes,M,22,196,88,United States,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Kevin Cordes,M,22,196,88,United States,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Kevin Cordes,M,22,196,88,United States,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,Gold
+"Joseph ""Joe"" Cordina",M,24,175,61,Great Britain,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Nicols Crdoba,M,26,165,71,Argentina,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Audrey Cordon (-Ragot),F,26,170,60,France,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Audrey Cordon (-Ragot),F,26,170,60,France,2016 Summer,Cycling,Cycling Women's Individual Time Trial,NA
+Kevin Haroldo Cordn Buezo,M,29,180,80,Guatemala,2016 Summer,Badminton,Badminton Men's Singles,NA
+Pilar Lucrecia Cordn Muro,F,43,175,58,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Pilar Lucrecia Cordn Muro,F,43,175,58,Spain,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Samuel Crdova Arvizu,M,27,200,89,Mexico,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Borna ori,M,19,185,75,Croatia,2016 Summer,Tennis,Tennis Men's Singles,NA
+Wendy Gabriela Cornejo Aliaga,F,23,162,54,Bolivia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Monique Adelinde Cornelissen,F,37,168,55,Netherlands,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Monique Adelinde Cornelissen,F,37,168,55,Netherlands,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Aliz Cornet,F,26,173,60,France,2016 Summer,Tennis,Tennis Women's Singles,NA
+Brbara Cornudella Ravetllat,F,23,160,50,Spain,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Stefany Mildred Coronado Gemio,F,19,173,54,Bolivia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Daniel Corral Barrn,M,26,173,64,Mexico,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Daniel Corral Barrn,M,26,173,64,Mexico,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+ngel Martn Correa Martnez,M,21,173,80,Argentina,2016 Summer,Football,Football Men's Football,NA
+Charles Fernando Corra,M,23,159,58,Brazil,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, Slalom",NA
+Harold Correa,M,28,190,81,France,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+"Francisco ""Quico"" Corts Juncosa",M,33,181,80,Spain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Javier Cortina Lacerra,M,29,185,97,Cuba,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Joana Ribeiro Costa,F,35,173,60,Brazil,2016 Summer,Athletics,Athletics Women's Pole Vault,NA
+Joo Carlos Calvete Pereira da Costa,M,51,182,100,Portugal,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Joo Carlos Calvete Pereira da Costa,M,51,182,100,Portugal,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Jos Lus Anica Costa,M,32,182,85,Portugal,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Keila da Silva da Costa,F,33,170,63,Brazil,2016 Summer,Athletics,Athletics Women's Long Jump,NA
+Keila da Silva da Costa,F,33,170,63,Brazil,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+Melania Felicitas Costa Schmid,F,27,180,69,Spain,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Melania Felicitas Costa Schmid,F,27,180,69,Spain,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Melania Felicitas Costa Schmid,F,27,180,69,Spain,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Melania Felicitas Costa Schmid,F,27,180,69,Spain,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Rayssa Costa de Oliveira,F,25,176,63,Brazil,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Rayssa Costa de Oliveira,F,25,176,63,Brazil,2016 Summer,Fencing,"Fencing Women's epee, Team",NA
+Rui Alberto Faria da Costa,M,29,183,68,Portugal,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Susana Cristina Sade da Costa,F,31,178,63,Portugal,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+Alin Coste,M,24,201,95,Romania,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Tanguy Cosyns,M,25,174,70,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+"John ""Johnno"" Cotterill",M,28,193,88,Australia,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Aleksandra Cotti,F,27,167,65,Italy,2016 Summer,Water Polo,Water Polo Women's Water Polo,Silver
+Tonia Couch,F,27,166,54,Great Britain,2016 Summer,Diving,Diving Women's Platform,NA
+Tonia Couch,F,27,166,54,Great Britain,2016 Summer,Diving,Diving Women's Synchronized Platform,NA
+Eoin Coughlan,M,24,186,81,Australia,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+James Coughlan,M,25,183,78,New Zealand,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Laurent Johann Jos Bourda Couhet,M,22,171,75,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Ismal Coulibaly,M,23,191,78,Mali,2016 Summer,Taekwondo,Taekwondo Men's Welterweight,NA
+DeMarcus Amir Cousins,M,25,210,122,United States,2016 Summer,Basketball,Basketball Men's Basketball,Gold
+Geisa Aparecida Muniz Coutinho,F,36,161,55,Brazil,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Geisa Aparecida Muniz Coutinho,F,36,161,55,Brazil,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Kurt Leonel da Rocha Couto,M,31,180,74,Mozambique,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Alicia Jayne Coutts,F,28,176,69,Australia,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Kirsty Leigh Coventry (-Seward),F,32,176,64,Zimbabwe,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Kirsty Leigh Coventry (-Seward),F,32,176,64,Zimbabwe,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,NA
+Rhydian Cowley,M,25,181,65,Australia,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Carmiesha Cox,F,21,168,61,Bahamas,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+J'den Michael Tbory Cox,M,21,180,86,United States,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Freestyle",Bronze
+John Arthur Cox Bransford IV,M,35,196,95,Venezuela,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Natalya Coyle,F,25,170,60,Ireland,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,NA
+"Amelia ""Amy"" Cozad",F,25,160,51,United States,2016 Summer,Diving,Diving Women's Synchronized Platform,NA
+Marius Vasile Cozmiuc,M,23,197,94,Romania,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Vanessa Cozzi,F,32,170,57,Brazil,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Morgan Craft,F,23,160,64,United States,2016 Summer,Shooting,Shooting Women's Skeet,NA
+Shanice Craft,F,23,185,93,Germany,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+"Kameryn Louise ""Kami"" Craig",F,29,181,88,United States,2016 Summer,Water Polo,Water Polo Women's Water Polo,Gold
+Brooke Leeann Crain,F,23,160,55,United States,2016 Summer,Cycling,Cycling Women's BMX,NA
+Lauren Crandall,F,31,161,58,United States,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Dan Craven,M,33,183,76,Namibia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Dan Craven,M,33,183,76,Namibia,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Sal Craviotto Rivero,M,31,192,98,Spain,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",Bronze
+Sal Craviotto Rivero,M,31,192,98,Spain,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",Gold
+Eric Shauwn Brazas Cray,M,27,176,70,Philippines,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Mauro Crenna,M,24,175,78,Italy,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+Mauro Crenna,M,24,175,78,Italy,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Pablo Crer,M,27,202,85,Argentina,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Edgar Roberto Crespo Echeverra,M,27,170,60,Panama,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Mariana Cress,F,17,159,52,Marshall Islands,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Anja Crevar,F,16,164,49,Serbia,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,NA
+Anja Crevar,F,16,164,49,Serbia,2016 Summer,Swimming,Swimming Women's 400 metres Individual Medley,NA
+Brittany Crew,F,22,178,112,Canada,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Adrian Crian,M,36,186,85,Romania,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Cristiane Rozeira de Souza Silva,F,31,176,69,Brazil,2016 Summer,Football,Football Women's Football,NA
+Jonas de Oliveira Crivella,M,28,181,82,Brazil,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Victoria Crivelli,F,25,176,65,Argentina,2016 Summer,Handball,Handball Women's Handball,NA
+Jovana Crnogorac,F,24,170,56,Serbia,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Louis Croenen,M,22,186,79,Belgium,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Louis Croenen,M,22,186,79,Belgium,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Jorrit Croon,M,17,183,75,Netherlands,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Hannah Cross,F,19,169,57,Australia,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+"Samuel Thomas ""Sam"" Cross",M,23,191,103,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Silver
+Will Crothers,M,29,195,95,Canada,2016 Summer,Rowing,Rowing Men's Coxless Fours,NA
+Jarred Crous,M,20,187,84,South Africa,2016 Summer,Swimming,Swimming Men's 200 metres Breaststroke,NA
+Ryan Crouser,M,23,201,125,United States,2016 Summer,Athletics,Athletics Men's Shot Put,Gold
+"Samuel ""Sam"" Crouser",M,24,198,105,United States,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+Ugo Jrme Franois Marc Crousillat,M,25,190,94,France,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Francisca Crovetto Chadid,F,26,160,54,Chile,2016 Summer,Shooting,Shooting Women's Skeet,NA
+Kvin Crovetto,M,24,183,81,Monaco,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Kvin Crovetto,M,24,183,81,Monaco,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Kvin Crovetto,M,24,183,81,Monaco,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Kvin Crovetto,M,24,183,81,Monaco,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Kvin Crovetto,M,24,183,81,Monaco,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Kvin Crovetto,M,24,183,81,Monaco,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+"Kimberley ""Kim"" Crow-Brennan",F,30,188,74,Australia,2016 Summer,Rowing,Rowing Women's Single Sculls,Gold
+Larissa Rose Crummer,F,20,178,70,Australia,2016 Summer,Football,Football Women's Football,NA
+Anna Cruz Lebrato,F,29,176,60,Spain,2016 Summer,Basketball,Basketball Women's Basketball,Silver
+"urea Esther ""Aury"" Cruz",F,34,180,63,Puerto Rico,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Eglis Yaima Cruz Farfn,F,36,159,63,Cuba,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Eglis Yaima Cruz Farfn,F,36,159,63,Cuba,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Aleksandra Crvendaki,F,20,187,76,Serbia,2016 Summer,Basketball,Basketball Women's Basketball,Bronze
+Dra Csabai,F,27,175,63,Hungary,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+"Lszl Cseh, Jr.",M,30,188,83,Hungary,2016 Summer,Swimming,Swimming Men's 100 metres Butterfly,Silver
+"Lszl Cseh, Jr.",M,30,188,83,Hungary,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Gspr Csere,M,24,172,54,Hungary,2016 Summer,Athletics,Athletics Men's Marathon,NA
+va Csernoviczki,F,29,160,51,Hungary,2016 Summer,Judo,Judo Women's Extra-Lightweight,NA
+Tamara Csipes,F,26,176,78,Hungary,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",Gold
+Lszl Csoknyai,M,28,172,83,Hungary,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Zsfia Katalin Csonka,F,32,164,89,Hungary,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+David Alejandro Cubilln Leon,M,29,183,79,Venezuela,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Uro ukovi,M,26,199,101,Montenegro,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Virginie Cueff,F,28,170,63,France,2016 Summer,Cycling,Cycling Women's Sprint,NA
+Virginie Cueff,F,28,170,63,France,2016 Summer,Cycling,Cycling Women's Keirin,NA
+Virginie Cueff,F,28,170,63,France,2016 Summer,Cycling,Cycling Women's Team Sprint,NA
+Gustavo Cuesta Rosario,M,27,183,80,Dominican Republic,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Gustavo Cuesta Rosario,M,27,183,80,Dominican Republic,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Vctor Leandro Cuesta,M,27,187,76,Argentina,2016 Summer,Football,Football Men's Football,NA
+Martn Esteban Cuestas,M,29,182,62,Uruguay,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Nicols Cuestas,M,29,180,63,Uruguay,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Fiorella Francesca Cueva Uribe,F,18,150,48,Peru,2016 Summer,Weightlifting,Weightlifting Women's Featherweight,NA
+Pablo Gabriel Cuevas Urroz,M,30,180,79,Uruguay,2016 Summer,Tennis,Tennis Men's Singles,NA
+Elizabeth Cui,F,18,159,58,New Zealand,2016 Summer,Diving,Diving Women's Springboard,NA
+Cui Qiuxia,F,25,166,63,China,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Lucien Cujean,M,26,184,82,Switzerland,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Milo uk,M,25,191,91,Serbia,2016 Summer,Water Polo,Water Polo Men's Water Polo,Gold
+Chay Crista Kerio Cullen,F,30,182,74,Great Britain,2016 Summer,Hockey,Hockey Women's Hockey,Gold
+Javier Culson Prez,M,32,200,82,Puerto Rico,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+"Stephen Phillip ""Steve"" Cummings",M,35,190,75,Great Britain,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Merewai Cumu,F,18,174,73,Fiji,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Rsul unayev,M,25,171,66,Azerbaijan,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Greco-Roman",Bronze
+Ana Marcela Jesus Soares da Cunha,F,24,165,66,Brazil,2016 Summer,Swimming,Swimming Women's 10 kilometres Open Water,NA
+Logan Perry Cunningham,M,25,175,73,United States,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Vashti Cunningham,F,18,185,56,United States,2016 Summer,Athletics,Athletics Women's High Jump,NA
+Petar Cupa,M,36,182,77,Croatia,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Ivan upi,M,30,178,78,Croatia,2016 Summer,Handball,Handball Men's Handball,NA
+Luca Cupido,M,20,188,95,United States,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Amy Louise Cure,F,23,172,63,Australia,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Taylor Curran,M,24,183,80,Canada,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Scott Curry,M,28,193,100,New Zealand,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+"Thomas ""Tom"" Cusack",M,23,191,101,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Luke Arron Cutts,M,28,188,82,Great Britain,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Adam Cwalina,M,31,187,81,Poland,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Mria Czakov,F,27,166,56,Slovakia,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Konrad Czerniak,M,27,193,78,Poland,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Konrad Czerniak,M,27,193,78,Poland,2016 Summer,Swimming,Swimming Men's 100 metres Butterfly,NA
+Konrad Czerniak,M,27,193,78,Poland,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Dra Czigny,F,23,173,60,Hungary,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Damian Czykier,M,23,191,78,Poland,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+"Abigail ""Abbey"" D'Agostino",F,24,160,50,United States,2016 Summer,Athletics,"Athletics Women's 5,000 metres",NA
+Michal D'Almeida,M,28,176,80,France,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Michal D'Almeida,M,28,176,80,France,2016 Summer,Cycling,Cycling Men's Team Sprint,Bronze
+Sabrina D'Angelo,F,23,173,71,Canada,2016 Summer,Football,Football Women's Football,Bronze
+Enrico D'Aniello,M,20,152,53,Italy,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Andrea Mitchell D'Arrigo,M,21,194,85,Italy,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Andrea Mitchell D'Arrigo,M,21,194,85,Italy,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Felipe Santos da Costa e Silva,M,31,196,103,Brazil,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Ruy Leme da Fonseca Filho,M,42,181,76,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Ruy Leme da Fonseca Filho,M,42,181,76,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Tain Mayara da Paixo,F,24,171,69,Brazil,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Duane Da Rocha Marc,F,28,180,60,Spain,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Duane Da Rocha Marc,F,28,180,60,Spain,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,NA
+Adilson Jos da Silva,M,44,175,75,Brazil,2016 Summer,Golf,Golf Men's Individual,NA
+Adriana Aparecida da Silva,F,35,166,52,Brazil,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Edson Isaas Freitas da Silva,M,34,170,83,Brazil,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+Edson Isaas Freitas da Silva,M,34,170,83,Brazil,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 200 metres",NA
+Fernanda Frana da Silva,F,26,176,68,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Gabrielle Mores da Silva,F,19,164,51,Brazil,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Holder Ocante da Silva,M,28,182,80,Guinea Bissau,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Joo Pedro Francisco da Silva,M,22,190,93,Brazil,2016 Summer,Handball,Handball Men's Handball,NA
+Mayra Aguiar da Silva,F,25,177,78,Brazil,2016 Summer,Judo,Judo Women's Half-Heavyweight,Bronze
+Pedro Henrique Gonalves da Silva,M,23,176,69,Brazil,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Rafael Carlos da Silva,M,29,203,160,Brazil,2016 Summer,Judo,Judo Men's Heavyweight,Bronze
+Rui Pedro S Alves da Silva,M,35,173,60,Portugal,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Aldemir Gomes da Silva Jnior,M,24,193,80,Brazil,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Nada Daabousov,F,19,165,52,Slovakia,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Kokoutse Fabrice Dabla,M,23,NA,NA,Togo,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Zoulehia Abzetta Dabonne,F,23,175,57,Cote d'Ivoire,2016 Summer,Judo,Judo Women's Lightweight,NA
+Ana Dabovi,F,26,183,70,Serbia,2016 Summer,Basketball,Basketball Women's Basketball,Bronze
+Milica Dabovi,F,34,173,63,Serbia,2016 Summer,Basketball,Basketball Women's Basketball,Bronze
+Sara Ilonka Dbritz,F,21,171,59,Germany,2016 Summer,Football,Football Women's Football,Gold
+"Gabriela ""Gaby"" Dabrowski",F,24,175,84,Canada,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Fedrick Dacres,M,22,191,104,Jamaica,2016 Summer,Athletics,Athletics Men's Discus Throw,NA
+Milana Kamilkhanovna Dadasheva,F,21,165,48,Russia,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Ivona Dadic,F,22,179,65,Austria,2016 Summer,Athletics,Athletics Women's Heptathlon,NA
+Anders Dahl,M,40,180,80,Denmark,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Anders Dahl,M,40,180,80,Denmark,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Sren Dahl,M,23,193,86,Denmark,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Anton Carl Diderik Dahlberg,M,31,182,71,Sweden,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Dan Anders Hkan Dahlby,M,50,185,95,Sweden,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+Gunn Rita Dahle-Flesj,F,43,173,64,Norway,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+"Jennifer ""Jenny"" Dahlgren Fitzner",F,32,180,110,Argentina,2016 Summer,Athletics,Athletics Women's Hammer Throw,NA
+Lisa Karolina Viktoria Dahlkvist,F,29,173,66,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Tobias Dahm,M,29,205,124,Germany,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Kenza Tifahi Dahmani,F,35,164,54,Algeria,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Neisi Patricia Dajomes Barrera,F,18,167,69,Ecuador,2016 Summer,Weightlifting,Weightlifting Women's Light-Heavyweight,NA
+Ro Masivesi Dakuwaqa,M,22,190,105,Fiji,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Gold
+Daniel Alfredo Dal Bo,M,28,185,78,Argentina,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+"Thomas Robert ""Tom"" Daley",M,22,177,74,Great Britain,2016 Summer,Diving,Diving Men's Platform,NA
+"Thomas Robert ""Tom"" Daley",M,22,177,74,Great Britain,2016 Summer,Diving,Diving Men's Synchronized Platform,Bronze
+"Phillip Peter ""Phil"" Dalhausser",M,36,206,93,United States-1,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Manol Dall'Igna,M,31,183,92,France,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Francesca Dallap,F,30,163,57,Italy,2016 Summer,Diving,Diving Women's Synchronized Springboard,Silver
+Chloe Elysha Dalton,F,23,180,72,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Gold
+"Jacob ""Jake"" Dalton",M,24,168,67,United States,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+"Jacob ""Jake"" Dalton",M,24,168,67,United States,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+"Jacob ""Jake"" Dalton",M,24,168,67,United States,2016 Summer,Gymnastics,Gymnastics Men's Horse Vault,NA
+"Jacob ""Jake"" Dalton",M,24,168,67,United States,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+"Jacob ""Jake"" Dalton",M,24,168,67,United States,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+"Jacob ""Jake"" Dalton",M,24,168,67,United States,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Dambadarjaagiin Gantulga,M,27,170,58,Mongolia,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Blandine Dancette,F,28,169,60,France,2016 Summer,Handball,Handball Women's Handball,Silver
+Silviya Georgieva Danekova,F,33,165,50,Bulgaria,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Anna Danesi,F,20,195,75,Italy,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Thibaut Amani Danho,M,22,185,82,Cote d'Ivoire,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Amas Daniel,M,26,165,65,Nigeria,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Freestyle",NA
+Debra Daniel,F,25,153,68,Federated States of Micronesia,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Emmanuel Shinkut Daniel,M,22,174,88,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Lucas Daniel,M,21,180,80,France,2016 Summer,Archery,Archery Men's Individual,NA
+Lucas Daniel,M,21,180,80,France,2016 Summer,Archery,Archery Men's Team,NA
+Taro Daniel,M,23,191,76,Japan,2016 Summer,Tennis,Tennis Men's Singles,NA
+Marcus Daniell,M,26,190,76,New Zealand,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Piotr Daniluk,M,34,175,72,Poland,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Piotr Daniluk,M,34,175,72,Poland,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+Mohamed Lamine Dansoko,M,18,161,78,Guinea,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+"Alexandra Mary L. ""Alex"" Danson",F,31,167,56,Great Britain,2016 Summer,Hockey,Hockey Women's Hockey,Gold
+Damiris Dantas do Amaral,F,23,192,80,Brazil,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Djnbou Dant,F,26,176,73,Mali,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+"Fabiana ""Dara"" Carvalho Carneiro Diniz",F,35,183,71,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Oussama Darfalou,M,22,187,75,Algeria,2016 Summer,Football,Football Men's Football,NA
+Hannah Darling,F,20,174,72,Canada,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Bronze
+Michael Darling,M,28,170,65,Ireland,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Darly Zogbi de Paula,F,33,178,70,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+Lisa Darmanin,F,24,168,65,Australia,2016 Summer,Sailing,Sailing Mixed Multihull,Silver
+Ron Darmon,M,23,175,65,Israel,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Maoulida Daroueche,M,26,177,60,Comoros,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+"Mackenzie ""Mack"" Darragh",M,22,185,79,Canada,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Ahmed Murad Darwish,M,35,172,80,Egypt,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Ramadan Darwish Ramadan Darwish,M,28,188,100,Egypt,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Atanu Das,M,24,175,79,India,2016 Summer,Archery,Archery Men's Individual,NA
+Mouma Das,F,32,149,47,India,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Oyeyemi Olugbenga Olatokunbo James Dasaolu,M,28,187,88,Great Britain,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Ana Iulia Dascl,F,13,183,60,Romania,2016 Summer,Swimming,Swimming Women's 100 metres Freestyle,NA
+Tuyana Norpolovna Dashidorzhiyeva,F,20,169,57,Russia,2016 Summer,Archery,Archery Women's Individual,NA
+Tuyana Norpolovna Dashidorzhiyeva,F,20,169,57,Russia,2016 Summer,Archery,Archery Women's Team,Silver
+Emmanuel Kwame Dasor,M,20,NA,NA,Ghana,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Micha Daszek,M,24,182,88,Poland,2016 Summer,Handball,Handball Men's Handball,NA
+Zurabi Datunashvili,M,25,183,75,Georgia,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Greco-Roman",NA
+Joris Nattan Daudet,M,25,184,78,France,2016 Summer,Cycling,Cycling Men's BMX,NA
+Christelle Daunay,F,41,162,43,France,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Soslan Tamazovich Daurov,M,25,164,60,Belarus,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Greco-Roman",NA
+Lukas Dauser,M,23,172,64,Germany,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Lukas Dauser,M,23,172,64,Germany,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Lukas Dauser,M,23,172,64,Germany,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Lukas Dauser,M,23,172,64,Germany,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Axelle Dauwens,F,25,171,62,Belgium,2016 Summer,Athletics,Athletics Women's 400 metres Hurdles,NA
+Davaadorjiin Tmrkhleg,M,25,172,70,Mongolia,2016 Summer,Judo,Judo Men's Half-Lightweight,NA
+Raijieli Daveua,F,24,NA,69,Fiji,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Areneo David,M,21,164,58,Malawi,2016 Summer,Archery,Archery Men's Individual,NA
+Klberson Davide,M,31,175,69,Brazil,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Maayan Davidovich,F,28,167,57,Israel,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Georgia Beth Davies,F,25,175,64,Great Britain,2016 Summer,Swimming,Swimming Women's 100 metres Backstroke,NA
+Georgia Beth Davies,F,25,175,64,Great Britain,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+James Davies,M,25,181,98,Great Britain,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Silver
+Desiree Nicole Davila-Linden,F,33,155,43,United States,2016 Summer,Athletics,Athletics Women's Marathon,NA
+James-Andrew Davis,M,25,195,98,Great Britain,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+James-Andrew Davis,M,25,195,98,Great Britain,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Lucy Davis,F,23,165,55,United States,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Lucy Davis,F,23,165,55,United States,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",Silver
+Lea Davison,F,33,168,55,United States,2016 Summer,Cycling,"Cycling Women's Mountainbike, Cross-Country",NA
+Artur Davtyan,M,23,162,55,Armenia,2016 Summer,Gymnastics,Gymnastics Men's Horse Vault,NA
+Hovhannes Davtyan,M,32,173,60,Armenia,2016 Summer,Judo,Judo Men's Extra-Lightweight,NA
+Valeriya Davydova,F,18,168,48,Uzbekistan,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Edward James Eddie Dawkins,M,27,185,93,New Zealand,2016 Summer,Cycling,Cycling Men's Sprint,NA
+Edward James Eddie Dawkins,M,27,185,93,New Zealand,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Edward James Eddie Dawkins,M,27,185,93,New Zealand,2016 Summer,Cycling,Cycling Men's Team Sprint,Silver
+"Matthew ""Matt"" Dawson",M,22,176,66,Australia,2016 Summer,Hockey,Hockey Men's Hockey,NA
+"Michael ""Mike"" Dawson",M,29,183,75,New Zealand,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Rachel Dawson,F,31,178,68,United States,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Christine Day,F,29,168,51,Jamaica,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Christine Day,F,29,168,51,Jamaica,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,Silver
+Marcus Vincius Carvalho Lopes D'Almeida,M,18,183,90,Brazil,2016 Summer,Archery,Archery Men's Individual,NA
+Marcus Vincius Carvalho Lopes D'Almeida,M,18,183,90,Brazil,2016 Summer,Archery,Archery Men's Team,NA
+De Jiaojiao,F,26,167,57,China,2016 Summer,Hockey,Hockey Women's Hockey,NA
+lvaro de Arriba Lpez,M,22,177,69,Spain,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Bruno Lins Tenrio de Barros,M,29,182,85,Brazil,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Bruno Lins Tenrio de Barros,M,29,182,85,Brazil,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Jasper De Buyst,M,22,178,69,Belgium,2016 Summer,Cycling,Cycling Men's Omnium,NA
+Tatiele Roberta de Carvalho,F,26,156,50,Brazil,2016 Summer,Athletics,"Athletics Women's 10,000 metres",NA
+Csar Augusto Aquino de Castro,M,33,175,72,Brazil,2016 Summer,Diving,Diving Men's Springboard,NA
+Luciano de Cecco,M,28,191,98,Argentina,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Csar Ernesto de Cesare Grassi,M,36,190,92,Ecuador,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+Nando de Colo,M,29,196,91,France,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Leonardo Gomes de Deus,M,25,175,70,Brazil,2016 Summer,Swimming,Swimming Men's 200 metres Backstroke,NA
+Leonardo Gomes de Deus,M,25,175,70,Brazil,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Giovanni De Gennaro,M,24,185,80,Italy,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Monica De Gennaro,F,29,174,67,Italy,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Lilian de Geus,F,24,164,57,Netherlands,2016 Summer,Sailing,Sailing Women's Windsurfer,NA
+Eva Roma Maria de Goede,F,27,170,61,Netherlands,2016 Summer,Hockey,Hockey Women's Hockey,Silver
+Andre De Grasse,M,21,176,70,Canada,2016 Summer,Athletics,Athletics Men's 100 metres,Bronze
+Andre De Grasse,M,21,176,70,Canada,2016 Summer,Athletics,Athletics Men's 200 metres,Silver
+Andre De Grasse,M,21,176,70,Canada,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,Bronze
+Robenlson Vieira de Jesus,M,28,166,56,Brazil,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Mark de Jonge,M,32,180,91,Canada,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+Juan Leon de Jongh,M,28,175,87,South Africa,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Bronze
+Mathilde de Kerangat,F,24,172,67,France,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Coen de Koning,M,33,183,74,Netherlands,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Robin de Kruijf,F,25,193,80,Netherlands,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Jovana de la Cruz Capani,F,24,161,53,Peru,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Juan Mara de la Fuente,M,39,181,74,Argentina,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Habib de las Salas de la Rosa,M,29,159,56,Colombia,2016 Summer,Weightlifting,Weightlifting Men's Bantamweight,NA
+Flvia Maria de Lima,F,23,176,65,Brazil,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Gustavo Augusto Roxo de Lima,M,39,185,82,Portugal,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Jailma Sales de Lima,F,29,174,65,Brazil,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Jailma Sales de Lima,F,29,174,65,Brazil,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Leonel de los Santos Nez,M,21,170,52,Dominican Republic,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Marco De Luca,M,35,188,70,Italy,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Riccardo De Luca,M,30,187,80,Italy,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Joo Bevilaqua de Lucca,M,26,193,96,Brazil,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Joo Bevilaqua de Lucca,M,26,193,96,Brazil,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Joo Bevilaqua de Lucca,M,26,193,96,Brazil,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Natalia de Luccas,F,19,167,63,Brazil,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Alessandro De Marchi,M,30,181,66,Italy,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Ian Carlos Gonalves de Matos,M,27,171,72,Brazil,2016 Summer,Diving,Diving Men's Synchronized Springboard,NA
+Martina De Memme,F,24,175,65,Italy,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Andressa Oliveira de Morais,F,25,178,97,Brazil,2016 Summer,Athletics,Athletics Women's Discus Throw,NA
+Marco Alessandro De Nicolo,M,39,180,83,Italy,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Marco Alessandro De Nicolo,M,39,180,83,Italy,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Marco Alessandro De Nicolo,M,39,180,83,Italy,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Mayobanex de leo,M,23,171,61,Dominican Republic,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Augusto Dutra de Oliveira,M,26,180,70,Brazil,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Ingrid de Oliveira,F,20,160,58,Brazil,2016 Summer,Diving,Diving Women's Platform,NA
+Ingrid de Oliveira,F,20,160,58,Brazil,2016 Summer,Diving,Diving Women's Synchronized Platform,NA
+Joo Vtor de Oliveira,M,24,190,87,Brazil,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Jlio Csar Miranda de Oliveira,M,30,185,95,Brazil,2016 Summer,Athletics,Athletics Men's Javelin Throw,NA
+Daynara Lopes Ferreira de Paula,F,27,163,55,Brazil,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Daynara Lopes Ferreira de Paula,F,27,163,55,Brazil,2016 Summer,Swimming,Swimming Women's 100 metres Butterfly,NA
+Daynara Lopes Ferreira de Paula,F,27,163,55,Brazil,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+Laurens De Plus,M,20,188,67,Belgium,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+rica Rocha de Sena,F,31,168,55,Brazil,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Joo Paulo de Leiria e Silva,M,51,176,90,Angola,2016 Summer,Shooting,Shooting Men's Trap,NA
+Leticia Cherpe de Souza,F,20,165,49,Brazil,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Jos Guilherme de Toledo,M,22,193,97,Brazil,2016 Summer,Handball,Handball Men's Handball,NA
+Zoe Michaela  de Toledo,F,29,172,58,Great Britain,2016 Summer,Rowing,Rowing Women's Coxed Eights,Silver
+Pablo Martn de Torres,M,32,190,86,Argentina,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Lisa Marie De Vanna,F,31,156,53,Australia,2016 Summer,Football,Football Women's Football,NA
+Bob de Voogd,M,27,183,80,Netherlands,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Xan de Waard,F,20,163,55,Netherlands,2016 Summer,Hockey,Hockey Women's Hockey,Silver
+Sander Sebastiaan de Wijn,M,26,183,78,Netherlands,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Frank de Wit,M,20,184,81,Netherlands,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Laura de Witte,F,20,173,61,Netherlands,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Lisanne de Witte,F,23,175,60,Netherlands,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,NA
+Anthony Dean,M,25,175,87,Australia,2016 Summer,Cycling,Cycling Men's BMX,NA
+"William ""Will"" Dean",M,29,195,95,Canada,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Timothy Deavin,M,32,185,77,Australia,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Fanny Deberghes,F,22,170,65,France,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,NA
+"Dbora Cristiane ""Debinha"" de Oliveira",F,24,157,55,Brazil,2016 Summer,Football,Football Women's Football,NA
+Gabriel Alejandro Deck,M,21,197,107,Argentina,2016 Summer,Basketball,Basketball Men's Basketball,NA
+dm Jozsef Decker,M,32,203,115,Hungary,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Attila Decker,M,28,197,94,Hungary,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Fernanda Demtrio Decnop Coelho,F,29,172,67,Brazil,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Tams Decsi,M,33,178,82,Hungary,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Andrea Deelstra,F,31,164,46,Netherlands,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Pablo Defazio Abella,M,35,170,67,Uruguay,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Hlne Defrance,F,29,179,66,France,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,Bronze
+Steffen Deibler,M,29,186,81,Germany,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Steffen Deibler,M,29,186,81,Germany,2016 Summer,Swimming,Swimming Men's 100 metres Butterfly,NA
+Steffen Deibler,M,29,186,81,Germany,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Francesca Deidda,F,24,164,49,Italy,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Veerle Dejaeghere,F,43,159,46,Belgium,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Iryna Mykhailivna Dekha,F,20,174,86,Ukraine,2016 Summer,Weightlifting,Weightlifting Women's Heavyweight,NA
+Inge Dekker,F,30,183,67,Netherlands,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Inge Dekker,F,30,183,67,Netherlands,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Dieter Dekoninck,M,25,190,85,Belgium,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Dieter Dekoninck,M,25,190,85,Belgium,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Stanly Jos del Carmen Cruz,M,20,163,62,Dominican Republic,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Stanly Jos del Carmen Cruz,M,20,163,62,Dominican Republic,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Antonella Del Core,F,35,180,75,Italy,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Marco Del Lungo,M,26,190,97,Italy,2016 Summer,Water Polo,Water Polo Men's Water Polo,Bronze
+ngela del Pan Moruno,F,31,173,68,Spain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Ajla Del Ponte,F,20,168,56,Switzerland,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Juan Martn del Potro,M,27,198,97,Argentina,2016 Summer,Tennis,Tennis Men's Singles,Silver
+Juan Martn del Potro,M,27,198,97,Argentina-1,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Diego Alan del Real Galindo,M,22,188,112,Mexico,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Matas Andrs del Solar Goldsmith,M,40,184,82,Chile,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Graham DeLaet,M,34,180,NA,Canada,2016 Summer,Golf,Golf Men's Individual,NA
+"Evangelos Ioannis ""Vangelis"" Delakas",M,31,189,90,Greece,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Sabrina Julienne Francine Delannoy,F,30,171,62,France,2016 Summer,Football,Football Women's Football,NA
+Barnab Delarze,M,22,193,100,Switzerland,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Miguel Delas de Andrs,M,32,170,72,Spain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Eric Delaunay,M,28,178,83,France,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Federico Delbonis,M,25,190,88,Argentina,2016 Summer,Tennis,Tennis Men's Singles,NA
+Federico Delbonis,M,25,190,88,Argentina-2,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Carlos Francisco Delfino,M,33,196,95,Argentina,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Lucien Delfour,M,27,177,69,Australia,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, Slalom",NA
+Angelica Delgado,F,25,160,52,United States,2016 Summer,Judo,Judo Women's Half-Lightweight,NA
+Lindolfo Delgado Garza,M,21,174,60,Mexico,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Marlo Delgado Suarez,M,23,184,75,Ecuador,2016 Summer,Boxing,Boxing Men's Middleweight,NA
+Cindy Solangie Delgado Buitrago,F,26,155,57,Colombia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Marcos Nicols Dela,M,24,209,105,Argentina,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Marie-Laure Delie,F,28,172,65,France,2016 Summer,Football,Football Women's Football,NA
+"Matthew ""Matt"" Dellavedova",M,25,193,89,Australia,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Elena Delle Donne,F,26,195,86,United States,2016 Summer,Basketball,Basketball Women's Basketball,Gold
+Nico Luca Marc Delle Karth,M,32,180,74,Austria,2016 Summer,Sailing,Sailing Men's Skiff,NA
+"Cynthia ""Janay"" DeLoach (-Soukup)",F,30,166,58,United States,2016 Summer,Athletics,Athletics Women's Long Jump,NA
+No Delpech,M,30,181,82,France,2016 Summer,Sailing,Sailing Men's Skiff,NA
+"Nicholas ""Nick"" Delpopolo",M,27,173,77,United States,2016 Summer,Judo,Judo Men's Lightweight,NA
+Siraba Dembl,F,30,172,64,France,2016 Summer,Handball,Handball Women's Handball,Silver
+Yigrem Demelash,M,22,167,48,Ethiopia,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Bence Demeter,M,26,180,72,Hungary,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Mirela Krasimirova Demireva,F,26,180,58,Bulgaria,2016 Summer,Athletics,Athletics Women's High Jump,Silver
+Ali Eren Demirezen,M,26,189,91,Turkey,2016 Summer,Boxing,Boxing Men's Super-Heavyweight,NA
+Soner Demirta,M,25,170,74,Turkey,2016 Summer,Wrestling,"Wrestling Men's Middleweight, Freestyle",Bronze
+Abdelghani Demmou,M,27,185,75,Algeria,2016 Summer,Football,Football Men's Football,NA
+"Nicholas Charles ""Nick"" Dempsey",M,35,180,71,Great Britain,2016 Summer,Sailing,Sailing Men's Windsurfer,Silver
+Valentin Demyanenko,M,32,193,93,Azerbaijan,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, 200 metres",Silver
+Felix Denayer,M,26,190,85,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,Bronze
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Deng Shudi,M,24,163,58,China,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Deng Wei,F,23,159,63,China,2016 Summer,Weightlifting,Weightlifting Women's Middleweight,Gold
+Deng Zhiwei,M,28,188,120,China,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Freestyle",NA
+Deni,M,27,165,69,Indonesia,2016 Summer,Weightlifting,Weightlifting Men's Middleweight,NA
+Stefan Denifl,M,28,179,65,Austria,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Aleksey Alekseyevich Denisenko,M,22,185,68,Russia,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,Silver
+Kirill Georgiyevich Denisov,M,28,182,90,Russia,2016 Summer,Judo,Judo Men's Middleweight,NA
+Zhansel Deniz,F,24,175,67,Kazakhstan,2016 Summer,Taekwondo,Taekwondo Women's Welterweight,NA
+Joel Dennerley,M,29,195,91,Australia,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Daniel Paul Dennis-Kengott,M,29,165,57,United States,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Rohan Dennis,M,26,182,72,Australia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Rohan Dennis,M,26,182,72,Australia,2016 Summer,Cycling,Cycling Men's Individual Time Trial,NA
+Matthew Denny,M,20,195,118,Australia,2016 Summer,Athletics,Athletics Men's Discus Throw,NA
+Erin Densham,F,31,165,52,Australia,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Deonise Fachinello Cavaleiro,F,33,180,73,Brazil,2016 Summer,Handball,Handball Women's Handball,NA
+Josue Deprez,M,34,NA,NA,Haiti,2016 Summer,Judo,Judo Men's Lightweight,NA
+Emel Dereli,F,20,181,110,Turkey,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Weronika Deresz,F,30,170,57,Poland,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Aleksey Viktorovich Dergunov,M,31,187,95,Kazakhstan,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+Aleksey Viktorovich Dergunov,M,31,187,95,Kazakhstan,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 1,000 metres",NA
+Inna Vasilyevna Deriglazova,F,26,173,61,Russia,2016 Summer,Fencing,"Fencing Women's Foil, Individual",Gold
+Senna Sandra Deriks,F,15,155,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Senna Sandra Deriks,F,15,155,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Dariya Derkach,F,23,170,50,Italy,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+DeMar Darnell DeRozan,M,26,201,99,United States,2016 Summer,Basketball,Basketball Men's Basketball,Gold
+Eli Dershwitz,M,20,185,77,United States,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Kateryna Oleksandrivna Derun,F,22,167,75,Ukraine,2016 Summer,Athletics,Athletics Women's Javelin Throw,NA
+Georgios Dervisis,M,21,195,92,Greece,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Nina Derwael,F,16,165,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Nina Derwael,F,16,165,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+Nina Derwael,F,16,165,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Nina Derwael,F,16,165,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Nina Derwael,F,16,165,46,Belgium,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Eseosa Fostine Desalu,M,22,180,67,Italy,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Mikkel Desler Puggaard,M,21,187,71,Denmark,2016 Summer,Football,Football Men's Football,NA
+Jrmy Desplanches,M,21,189,72,Switzerland,2016 Summer,Swimming,Swimming Men's 200 metres Individual Medley,NA
+Jrmy Desplanches,M,21,189,72,Switzerland,2016 Summer,Swimming,Swimming Men's 400 metres Individual Medley,NA
+Gabriele Detti,M,21,184,79,Italy,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,Bronze
+Gabriele Detti,M,21,184,79,Italy,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",Bronze
+Gabriele Detti,M,21,184,79,Italy,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Team All-Around,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Bart Deurloo,M,25,170,65,Netherlands,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+Daniel Deuer,M,34,190,76,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Daniel Deuer,M,34,190,76,Germany,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",Bronze
+Laishram Bombayla Devi,F,31,164,60,India,2016 Summer,Archery,Archery Women's Individual,NA
+Laishram Bombayla Devi,F,31,164,60,India,2016 Summer,Archery,Archery Women's Team,NA
+Timofey Aleksandrovich Deynichenko,M,29,186,98,Belarus,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Greco-Roman",NA
+Tatjana ekanovi,F,19,167,52,Bosnia and Herzegovina,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+Ana erek,F,17,164,58,Croatia,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Ana erek,F,17,164,58,Croatia,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Ana erek,F,17,164,58,Croatia,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Jeroen D'hoedt,M,26,183,63,Belgium,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Jolien D'hoore,F,26,176,64,Belgium,2016 Summer,Cycling,Cycling Women's Omnium,Bronze
+Ayyasamy Dharun,M,19,177,64,India,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Yosra Dhieb,F,20,178,123,Tunisia,2016 Summer,Weightlifting,Weightlifting Women's Super-Heavyweight,NA
+Dhurgham Ismail Dawoud Al-Quraishi,M,22,178,70,Iraq,2016 Summer,Football,Football Men's Football,NA
+Marco Di Costanzo,M,24,184,87,Italy,2016 Summer,Rowing,Rowing Men's Coxless Pairs,Bronze
+Elisa Di Francisca,F,33,177,65,Italy,2016 Summer,Fencing,"Fencing Women's Foil, Individual",Silver
+Francesco Di Fulvio,M,22,190,88,Italy,2016 Summer,Water Polo,Water Polo Men's Water Polo,Bronze
+Alex Di Giorgio,M,26,185,75,Italy,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Tania Di Mario,F,37,168,62,Italy,2016 Summer,Water Polo,Water Polo Women's Water Polo,Silver
+Silvia Di Pietro,F,23,165,57,Italy,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Silvia Di Pietro,F,23,165,57,Italy,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+Mamadou Chrif Dia,M,31,180,70,Mali,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Sahily Diago Mesa,F,20,169,49,Cuba,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Emily Jane Diamond,F,25,173,58,Great Britain,2016 Summer,Athletics,Athletics Women's 400 metres,NA
+Emily Jane Diamond,F,25,173,58,Great Britain,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,Bronze
+Kadidiatou Diani,F,21,168,64,France,2016 Summer,Football,Football Women's Football,NA
+Diao Xiao Juan,F,30,170,59,Hong Kong,2016 Summer,Cycling,Cycling Women's Omnium,NA
+Maimouna Diarra,F,25,198,90,Senegal,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Clio Emilson Ucha Dias,M,23,192,90,Portugal,2016 Summer,Judo,Judo Men's Middleweight,NA
+Gabriela Mantellato Dias,F,24,175,76,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Adama Diatta,M,27,165,57,Senegal,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Boris Babacar Diaw-Riffiod,M,34,203,115,France,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Adriana Yamila Daz Gonzlez,F,15,160,50,Puerto Rico,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Azucena Daz Calvo,F,33,163,55,Spain,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Daniel Ricardo Daz,M,27,168,63,Argentina,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Mara Gabriela Daz,F,35,160,53,Argentina,2016 Summer,Cycling,Cycling Women's BMX,NA
+Hidilyn Diaz,F,25,149,53,Philippines,2016 Summer,Weightlifting,Weightlifting Women's Featherweight,Silver
+Jorge Daz Garca,M,30,173,75,Spain,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Jos Daniel Daz Robertti,M,27,181,96,Venezuela,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Jos Ignacio Daz Velzquez,M,36,168,67,Spain,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Nivaldo Nadhir Daz Gmez,M,22,200,81,Cuba,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Genzebe Dibaba Keneni,F,25,168,52,Ethiopia,2016 Summer,Athletics,"Athletics Women's 1,500 metres",Silver
+Mare Dibaba Hurssa (-Ibrahimova-),F,26,156,45,Ethiopia,2016 Summer,Athletics,Athletics Women's Marathon,Bronze
+Tirunesh Dibaba Keneni,F,31,166,50,Ethiopia,2016 Summer,Athletics,"Athletics Women's 10,000 metres",Bronze
+Marisa Roseanne Dick,F,19,153,47,Trinidad and Tobago,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Marisa Roseanne Dick,F,19,153,47,Trinidad and Tobago,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Marisa Roseanne Dick,F,19,153,47,Trinidad and Tobago,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Marisa Roseanne Dick,F,19,153,47,Trinidad and Tobago,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Kylie Rei Dickson,F,17,160,50,Belarus,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Kylie Rei Dickson,F,17,160,50,Belarus,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Kylie Rei Dickson,F,17,160,50,Belarus,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Kylie Rei Dickson,F,17,160,50,Belarus,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Sam Dickson,M,26,193,101,New Zealand,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Amalie Dideriksen,F,20,175,62,Denmark,2016 Summer,Cycling,Cycling Women's Omnium,NA
+Aurimas Didbalis,M,25,172,94,Lithuania,2016 Summer,Weightlifting,Weightlifting Men's Middle-Heavyweight,Bronze
+Hortence Didhiou,F,32,165,57,Senegal,2016 Summer,Judo,Judo Women's Lightweight,NA
+Rodrigo Diego Lpez,M,19,166,69,Mexico,2016 Summer,Diving,Diving Men's Springboard,NA
+Mitch Dielemans,M,23,186,75,Netherlands,2016 Summer,Archery,Archery Men's Individual,NA
+Mitch Dielemans,M,23,186,75,Netherlands,2016 Summer,Archery,Archery Men's Team,NA
+Bintou Dim,F,32,167,58,Senegal,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Christian Diener,M,23,182,82,Germany,2016 Summer,Swimming,Swimming Men's 200 metres Backstroke,NA
+Fatou Dieng,F,32,167,60,Senegal,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Heidi Diethelm Gerber,F,47,168,93,Switzerland,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Heidi Diethelm Gerber,F,47,168,93,Switzerland,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",Bronze
+Tina Dietze,F,28,172,68,Germany,2016 Summer,Canoeing,"Canoeing Women's Kayak Doubles, 500 metres",Silver
+Tina Dietze,F,28,172,68,Germany,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",Silver
+Balla Diye,M,35,188,68,Senegal,2016 Summer,Taekwondo,Taekwondo Men's Featherweight,NA
+Lizbeth Julissa Diez Canseco,F,27,170,49,Peru,2016 Summer,Taekwondo,Taekwondo Women's Flyweight,NA
+Laura Chantal Dijkema,F,26,184,70,Netherlands,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Yusuf Dike,M,43,180,80,Turkey,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Yusuf Dike,M,43,180,80,Turkey,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Karsten Dilla,M,27,188,82,Germany,2016 Summer,Athletics,Athletics Men's Pole Vault,NA
+Silvan Dillier,M,26,183,73,Switzerland,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",NA
+Stefanos Dimitriadis,M,26,189,82,Greece,2016 Summer,Swimming,Swimming Men's 200 metres Butterfly,NA
+Dimitrios Dimitriou,M,19,179,72,Greece,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Grigor Dimitrov Dimitrov,M,25,190,81,Bulgaria,2016 Summer,Tennis,Tennis Men's Singles,NA
+Rumen Dimitrov,M,29,175,77,Bulgaria,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Ding Ning,F,26,171,63,China,2016 Summer,Table Tennis,Table Tennis Women's Singles,Gold
+Ding Ning,F,26,171,63,China,2016 Summer,Table Tennis,Table Tennis Women's Team,Gold
+Ding Xia,F,26,180,67,China,2016 Summer,Volleyball,Volleyball Women's Volleyball,Gold
+Ding Yanyuhang,M,22,200,91,China,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Shawn Erbelau Dingilius-Wallace,M,22,184,93,Palau,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Oliver James Dingley,M,23,163,60,Ireland,2016 Summer,Diving,Diving Men's Springboard,NA
+Yohann Diniz,M,38,185,66,France,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Luciana Diniz-Knippling,F,45,175,55,Portugal,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Loredana Dinu (Iordchioiu-),F,32,168,60,Romania,2016 Summer,Fencing,"Fencing Women's epee, Team",Gold
+"Ikechukwu Somtochukwu ""Ike"" Diogu",M,32,206,115,Nigeria,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Nuria Lidn Diosdado Garca,F,25,170,55,Mexico,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Antoine Diot,M,27,193,86,France,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Mame Diodio Diouf,F,31,170,70,Senegal,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Adrien Dipanda,M,28,202,105,France,2016 Summer,Handball,Handball Men's Handball,Silver
+"Madeline Jane ""Maya"" DiRado",F,23,175,65,United States,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,Gold
+"Madeline Jane ""Maya"" DiRado",F,23,175,65,United States,2016 Summer,Swimming,Swimming Women's 200 metres Backstroke,Gold
+"Madeline Jane ""Maya"" DiRado",F,23,175,65,United States,2016 Summer,Swimming,Swimming Women's 200 metres Individual Medley,Bronze
+"Madeline Jane ""Maya"" DiRado",F,23,175,65,United States,2016 Summer,Swimming,Swimming Women's 400 metres Individual Medley,Silver
+Carlien Clemens Dirkse van den Heuvel,F,29,170,56,Netherlands,2016 Summer,Hockey,Hockey Women's Hockey,Silver
+Etenesh Diro Neda,F,25,168,49,Ethiopia,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Michael DiSanto,M,26,185,91,United States,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Wiam Dislam,F,28,180,69,Morocco,2016 Summer,Taekwondo,Taekwondo Women's Heavyweight,NA
+Christian Dissinger,M,24,203,105,Germany,2016 Summer,Handball,Handball Men's Handball,Bronze
+Cline Distel-Bonnet,F,29,170,69,France,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Dominik Distelberger,M,26,186,81,Austria,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Adam Graham Dixon,M,29,169,70,Great Britain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Alyson Dixon,F,37,155,43,Great Britain,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Tervel Ivaylov Dlagnev,M,30,188,122,United States,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Freestyle",NA
+Amanda Sinegugu Dlamini,F,28,162,61,South Africa,2016 Summer,Football,Football Women's Football,NA
+Mariya Dmitriyenko,F,28,167,56,Kazakhstan,2016 Summer,Shooting,Shooting Women's Trap,NA
+Denis Sergeyevich Dmitriyev,M,30,177,90,Russia,2016 Summer,Cycling,Cycling Men's Sprint,Bronze
+Denis Sergeyevich Dmitriyev,M,30,177,90,Russia,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Darya Yevgenyevna Dmitriyeva,F,20,178,74,Russia,2016 Summer,Handball,Handball Women's Handball,Gold
+Lyudmila Vladimirovna Dmitriyeva,F,27,180,70,Russia,2016 Summer,Sailing,Sailing Women's Two Person Dinghy,NA
+Olena Mykolavna Dmytrash,F,24,173,51,Ukraine,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Ruslan Hryhorovych Dmytrenko,M,30,180,67,Ukraine,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Nicolas d'Oriano,M,19,175,68,France,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Julien d'Ortoli,M,32,180,75,France,2016 Summer,Sailing,Sailing Men's Skiff,NA
+Allan Lopes Mamdio do Carmo,M,27,174,73,Brazil,2016 Summer,Swimming,Swimming Men's 10 kilometres Open Water,NA
+Patryk Dobek,M,22,187,75,Poland,2016 Summer,Athletics,Athletics Men's 400 metres Hurdles,NA
+Charlotte Dobson,F,30,168,62,Great Britain,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Sbastien Dockier,M,26,175,74,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+"Alvaro Affonso ""Doda"" de Miranda Neto",M,43,186,86,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+"Alvaro Affonso ""Doda"" de Miranda Neto",M,43,186,86,Brazil,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Kyle Dodd,M,22,178,80,South Africa,2016 Summer,Cycling,Cycling Men's BMX,NA
+Tony Boyd Dodds,M,29,183,68,New Zealand,2016 Summer,Triathlon,Triathlon Men's Olympic Distance,NA
+Jeremy Dodson,M,28,180,72,Samoa,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Patrick Dogue,M,24,197,81,Germany,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Carl Dohmann,M,26,183,62,Germany,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+John-John Dohmen,M,28,174,69,Belgium,2016 Summer,Hockey,Hockey Men's Hockey,Silver
+Kazuto Doi,M,24,175,65,Japan,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Manami Doi,F,22,167,64,Japan,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Misaki Doi,F,25,159,55,Japan,2016 Summer,Tennis,Tennis Women's Singles,NA
+Misaki Doi,F,25,159,55,Japan,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Eleni Doika,F,20,168,49,Greece,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Jure Dolenec,M,27,190,93,Slovenia,2016 Summer,Handball,Handball Men's Handball,NA
+Mariya Sergeyevna Dolgikh (Zelenova-),F,29,176,62,Russia,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Mikhail Viktorovich Dolgolevets,M,26,185,81,Belarus,2016 Summer,Boxing,Boxing Men's Light-Heavyweight,NA
+Irina Yuryevna Dolgova,F,20,153,48,Russia,2016 Summer,Judo,Judo Women's Extra-Lightweight,NA
+Maksym Eduardovych Dolhov,M,20,176,71,Ukraine,2016 Summer,Diving,Diving Men's Synchronized Platform,NA
+Keagan Larenzo Dolly,M,23,173,67,South Africa,2016 Summer,Football,Football Men's Football,NA
+Tiberiu Alexandru Dolniceanu,M,28,179,79,Romania,2016 Summer,Fencing,"Fencing Men's Sabre, Individual",NA
+Marina Frantsevna Domantsevich,F,32,162,51,Belarus,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Wuta Waco Bige Dombaxi,F,30,180,92,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Wagner Jos Alberto Carvalho Domingos,M,33,187,100,Brazil,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Mnica Patricia Domnguez Lara,F,28,162,58,Mexico,2016 Summer,Weightlifting,Weightlifting Women's Lightweight,NA
+Slvia Domnguez Fernndez,F,29,167,64,Spain,2016 Summer,Basketball,Basketball Women's Basketball,Silver
+Sam Dommer,M,24,188,92,United States,2016 Summer,Rowing,Rowing Men's Coxed Eights,NA
+Apisai Raviyawa Domolailai,M,27,192,98,Fiji,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,Gold
+Fabrizio Donato,M,39,189,83,Italy,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Franco Peru Donato,M,34,165,64,Egypt,2016 Summer,Shooting,Shooting Men's Skeet,NA
+Karin Donckers,F,45,168,57,Belgium,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Nazl ala Dnerta,F,25,173,69,Turkey,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Dong Bin,M,27,180,74,China,2016 Summer,Athletics,Athletics Men's Triple Jump,Bronze
+Dong Dong,M,27,168,57,China,2016 Summer,Trampolining,Trampolining Men's Individual,Silver
+Dong Guojian,M,29,170,55,China,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Dong Jie,F,17,170,62,China,2016 Summer,Swimming,Swimming Women's 4 x 200 metres Freestyle Relay,NA
+Auriol Dongmo Mekemnang,F,26,173,95,Cameroon,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Rubens Valeriano Donizete,M,36,173,69,Brazil,2016 Summer,Cycling,"Cycling Men's Mountainbike, Cross-Country",NA
+Samuil Emilov Donkov,M,33,170,68,Bulgaria,2016 Summer,Shooting,"Shooting Men's Air Pistol, 10 metres",NA
+Samuil Emilov Donkov,M,33,170,68,Bulgaria,2016 Summer,Shooting,"Shooting Men's Free Pistol, 50 metres",NA
+Steven Gerard Donnelly,M,27,180,69,Ireland,2016 Summer,Boxing,Boxing Men's Welterweight,NA
+Yevgeny Yevganyevich Donskoy,M,26,185,74,Russia,2016 Summer,Tennis,Tennis Men's Singles,NA
+Hoi Kem Doo,F,19,166,60,Hong Kong,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Hoi Kem Doo,F,19,166,60,Hong Kong,2016 Summer,Table Tennis,Table Tennis Women's Team,NA
+Logan Dooley,M,28,175,59,United States,2016 Summer,Trampolining,Trampolining Men's Individual,NA
+Valdas Dopolskas,M,24,183,69,Lithuania,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Clemens Doppler,M,35,200,87,Austria-2,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Troy Doris,M,27,172,74,Guyana,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Dorjkhandyn Khderbulga,M,24,181,102,Mongolia,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Freestyle",NA
+Dorjnyambuugiin Otgondalai,M,28,170,60,Mongolia,2016 Summer,Boxing,Boxing Men's Lightweight,Bronze
+Dorjsurengiin Sumiya,F,25,160,59,Mongolia,2016 Summer,Judo,Judo Women's Lightweight,Silver
+Sam Dorman,M,24,175,77,United States,2016 Summer,Diving,Diving Men's Synchronized Springboard,Silver
+Frantz Mike Itelord Dorsainvil,M,25,170,59,Haiti,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Ane Marcelle Gomes dos Santos,F,22,153,53,Brazil,2016 Summer,Archery,Archery Women's Individual,NA
+Ane Marcelle Gomes dos Santos,F,22,153,53,Brazil,2016 Summer,Archery,Archery Women's Team,NA
+Clarissa Cristina dos Santos,F,28,183,89,Brazil,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Janete Viegas dos Santos,F,25,175,68,Angola,2016 Summer,Handball,Handball Women's Handball,NA
+Jlia Vasconcelos dos Santos,F,24,173,57,Brazil,2016 Summer,Taekwondo,Taekwondo Women's Featherweight,NA
+Marlson Gomes dos Santos,M,38,174,58,Brazil,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Marily dos Santos,F,38,158,46,Brazil,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Peterson dos Santos,M,25,181,70,Brazil,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,NA
+Thiagus Petrus Gonalves dos Santos,M,27,198,104,Brazil,2016 Summer,Handball,Handball Men's Handball,NA
+Vtor Hugo Silva Mouro dos Santos,M,20,185,74,Brazil,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Vtor Hugo Silva Mouro dos Santos,M,20,185,74,Brazil,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Mrio Jos dos Santos Jnior,M,36,171,60,Brazil,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Sara Dosho,F,21,159,69,Japan,2016 Summer,Wrestling,"Wrestling Women's Light-Heavyweight, Freestyle",Gold
+Celtus Williams Abiola Dossou Yovo,M,30,175,89,Benin,2016 Summer,Judo,Judo Men's Middleweight,NA
+Josef Dostl,M,23,202,115,Czech Republic,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 1,000 metres",Silver
+Josef Dostl,M,23,202,115,Czech Republic,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",Bronze
+Luca Dotto,M,26,192,80,Italy,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Luca Dotto,M,26,192,80,Italy,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Luca Dotto,M,26,192,80,Italy,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,NA
+Luca Dotto,M,26,192,80,Italy,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,NA
+Natasa Douchev-Janics,F,34,174,68,Hungary,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, 200 metres",NA
+Gabriella Al-Doueihy,F,17,NA,NA,Lebanon,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+"Gabrielle Christina Victoria ""Gabby"" Douglas",F,20,157,50,United States,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+"Gabrielle Christina Victoria ""Gabby"" Douglas",F,20,157,50,United States,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,Gold
+"Gabrielle Christina Victoria ""Gabby"" Douglas",F,20,157,50,United States,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+"Gabrielle Christina Victoria ""Gabby"" Douglas",F,20,157,50,United States,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+"Gabrielle Christina Victoria ""Gabby"" Douglas",F,20,157,50,United States,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Douglas dos Santos Justino de Melo,M,22,173,69,Brazil,2016 Summer,Football,Football Men's Football,Gold
+Owain Daniel John Doull,M,23,181,73,Great Britain,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",Gold
+"Konstantinos Alexandros ""Kostas"" Douvalidis-Ricks",M,29,181,78,Greece,2016 Summer,Athletics,Athletics Men's 110 metres Hurdles,NA
+Mikhail Dzhavanshirovich Dovgalyuk,M,21,NA,NA,Russia,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Ivan Viktorovych Dovhodko,M,27,196,100,Ukraine,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Anna Dowgiert,F,26,178,65,Poland,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Anna Dowgiert,F,26,178,65,Poland,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,NA
+"Rebecca Lauren ""Beckie"" Downie",F,24,156,55,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+"Rebecca Lauren ""Beckie"" Downie",F,24,156,55,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+"Rebecca Lauren ""Beckie"" Downie",F,24,156,55,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+"Elissa Rebecca Louis ""Ellie"" Downie",F,17,162,60,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+"Elissa Rebecca Louis ""Ellie"" Downie",F,17,162,60,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Team All-Around,NA
+"Elissa Rebecca Louis ""Ellie"" Downie",F,17,162,60,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+"Elissa Rebecca Louis ""Ellie"" Downie",F,17,162,60,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Horse Vault,NA
+"Elissa Rebecca Louis ""Ellie"" Downie",F,17,162,60,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+"Elissa Rebecca Louis ""Ellie"" Downie",F,17,162,60,Great Britain,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Fiona Doyle,F,24,175,65,Ireland,2016 Summer,Swimming,Swimming Women's 100 metres Breaststroke,NA
+Fiona Doyle,F,24,175,65,Ireland,2016 Summer,Swimming,Swimming Women's 200 metres Breaststroke,NA
+Lauren Doyle,F,25,168,68,United States,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+ Th Anh,F,20,165,58,Vietnam,2016 Summer,Fencing,"Fencing Women's Foil, Individual",NA
+Novak okovi,M,29,188,80,Serbia,2016 Summer,Tennis,Tennis Men's Singles,NA
+Novak okovi,M,29,188,80,Serbia,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Jonathan Drack,M,27,184,73,Mauritius,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Marin Draganja,M,25,185,80,Croatia,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Marie-Louise Drger,F,35,170,59,Germany,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Marian Drgulescu,M,35,163,64,Romania,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Marian Drgulescu,M,35,163,64,Romania,2016 Summer,Gymnastics,Gymnastics Men's Horse Vault,NA
+Marian Drgulescu,M,35,163,64,Romania,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Aneka Drahotov,F,21,180,57,Czech Republic,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Felix Drahotta,M,27,200,102,Germany,2016 Summer,Rowing,Rowing Men's Coxed Eights,Silver
+Theodora Drakou,F,24,169,67,Greece,2016 Summer,Swimming,Swimming Women's 50 metres Freestyle,NA
+Rok Draki,M,29,166,75,Slovenia,2016 Summer,Judo,Judo Men's Lightweight,NA
+Zakaria Draoui,M,22,160,60,Algeria,2016 Summer,Football,Football Men's Football,NA
+"Jessica Margaret Aida ""Jess"" Draskau-Petersson",F,38,170,62,Denmark,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Yevgeny Yuryevich Drattsev,M,33,180,74,Russia,2016 Summer,Swimming,Swimming Men's 10 kilometres Open Water,NA
+Rasa Drazdauskait,F,35,173,58,Lithuania,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Dion Christian Dreesens,M,23,195,88,Netherlands,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Dion Christian Dreesens,M,23,195,88,Netherlands,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Jale Dreloa,M,21,187,88,Fiji,2016 Summer,Football,Football Men's Football,NA
+Caeleb Remel Dressel,M,19,191,86,United States,2016 Summer,Swimming,Swimming Men's 100 metres Freestyle,NA
+Caeleb Remel Dressel,M,19,191,86,United States,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,Gold
+Caeleb Remel Dressel,M,19,191,86,United States,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Medley Relay,Gold
+Giulio Dressino,M,23,183,75,Italy,2016 Summer,Canoeing,"Canoeing Men's Kayak Doubles, 1,000 metres",NA
+Giulio Dressino,M,23,183,75,Italy,2016 Summer,Canoeing,"Canoeing Men's Kayak Fours, 1,000 metres",NA
+Paul Andrew Drinkhall,M,26,176,80,Great Britain,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Paul Andrew Drinkhall,M,26,176,80,Great Britain,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+"Katherine Joan ""Kat"" Driscoll",F,30,168,55,Great Britain,2016 Summer,Trampolining,Trampolining Women's Individual,NA
+Derek Drouin,M,26,196,83,Canada,2016 Summer,Athletics,Athletics Men's High Jump,Gold
+Tatyana Yevgenyevna Drozdovskaya,F,37,175,69,Belarus,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+Daniela Druncea,F,25,150,50,Romania,2016 Summer,Rowing,Rowing Women's Coxed Eights,Bronze
+Paul Drux,M,21,192,106,Germany,2016 Summer,Handball,Handball Men's Handball,Bronze
+Ilya Andreyevich Druzhinin,M,18,173,63,Russia,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Mark William Dry,M,28,184,113,Great Britain,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Monika Mariola Drybulska-Stefanowicz,F,36,160,46,Poland,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Alexander Mah Owens Drysdale,M,37,200,102,New Zealand,2016 Summer,Rowing,Rowing Men's Single Sculls,Gold
+Fabian Drzyzga,M,26,196,90,Poland,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Du Li,F,34,170,55,China,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",Silver
+Du Li,F,34,170,55,China,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",Bronze
+Duan Jingli,F,27,180,76,China,2016 Summer,Rowing,Rowing Women's Single Sculls,Bronze
+Emerson Duarte,M,44,182,80,Brazil,2016 Summer,Shooting,"Shooting Men's Rapid-Fire Pistol, 25 metres",NA
+talo Manzine Amaral Duarte Garfalo,M,24,180,73,Brazil,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Mariana Rog Duarte,F,19,170,67,Brazil,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Jeroen Dubbeldam,M,43,185,85,Netherlands,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Jeroen Dubbeldam,M,43,185,85,Netherlands,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Preeti Dubey,F,18,166,53,India,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Alyona Viktorovna Dubitskaya (Grishko-),F,26,180,76,Belarus,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Cedric Dubler,M,21,191,NA,Australia,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Vladimir Vladimirov Dubov,M,28,156,64,Bulgaria,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Andrs Claudio Ducasse Rojas,M,24,171,70,Chile,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Francisco Ducasse Rojas,M,19,175,68,Chile,2016 Summer,Sailing,Sailing Men's Two Person Dinghy,NA
+Krista DuChene,F,39,167,54,Canada,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Antoine Duchesne,M,24,189,73,Canada,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Natalia Duc Soler,F,27,177,100,Chile,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Mihail Duda,M,26,184,85,Serbia,2016 Summer,Athletics,Athletics Men's Decathlon,NA
+Anna Sergeyevna Dudenkova,F,22,167,51,Belarus,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Crispin Nataniel Duenas,M,30,172,81,Canada,2016 Summer,Archery,Archery Men's Individual,NA
+Annette Duetz,F,23,180,74,Netherlands,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Justin Duff,M,28,200,102,Canada,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Flora Jane Duffy,F,28,163,57,Bermuda,2016 Summer,Triathlon,Triathlon Women's Olympic Distance,NA
+Albta Dufkov,F,26,172,60,Czech Republic,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Duet,NA
+Cathrine Dufour,F,24,170,68,Denmark,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",NA
+Cathrine Dufour,F,24,170,68,Denmark,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",NA
+Dominic Dugasse,M,31,188,99,Seychelles,2016 Summer,Judo,Judo Men's Half-Heavyweight,NA
+Damir Dugonji,M,28,202,105,Slovenia,2016 Summer,Swimming,Swimming Men's 100 metres Breaststroke,NA
+Romain Duguet,M,35,176,68,Switzerland,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Romain Duguet,M,35,176,68,Switzerland,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Team",NA
+Charlotte Susan Jane Dujardin,F,31,170,57,Great Britain,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Individual",Gold
+Charlotte Susan Jane Dujardin,F,31,170,57,Great Britain,2016 Summer,Equestrianism,"Equestrianism Mixed Dressage, Team",Silver
+Jana Duktov,F,33,180,64,Slovakia,2016 Summer,Canoeing,"Canoeing Women's Kayak Singles, Slalom",NA
+Milivoj Duki,M,23,185,83,Montenegro,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Kelly Dulfer,F,22,185,78,Netherlands,2016 Summer,Handball,Handball Women's Handball,NA
+Valeriu Duminic,M,29,175,81,Moldova,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Tom Dumoulin,M,25,186,70,Netherlands,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Tom Dumoulin,M,25,186,70,Netherlands,2016 Summer,Cycling,Cycling Men's Individual Time Trial,Silver
+Vitaly Vladimirovich Dunaytsev,M,24,174,64,Russia,2016 Summer,Boxing,Boxing Men's Light-Welterweight,Bronze
+Evan Dunfee,M,25,182,70,Canada,2016 Summer,Athletics,Athletics Men's 20 kilometres Walk,NA
+Evan Dunfee,M,25,182,70,Canada,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Fitzroy Junior Dunkley,M,23,195,79,Jamaica,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Fitzroy Junior Dunkley,M,23,195,79,Jamaica,2016 Summer,Athletics,Athletics Men's 4 x 400 metres Relay,Silver
+Joshua Dunkley-Smith,M,27,194,98,Australia,2016 Summer,Rowing,Rowing Men's Coxless Fours,Silver
+Crystal Alyssia Dunn,F,24,157,56,United States,2016 Summer,Football,Football Women's Football,NA
+Thomas Dunstan,M,18,194,96,United States,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Duo Bujie,M,22,175,55,China,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Pierre Duprat,M,26,175,73,France,2016 Summer,Judo,Judo Men's Lightweight,NA
+Lucas Rodriques Duque,M,32,170,84,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Mariana Duque Mario,F,26,169,61,Colombia,2016 Summer,Tennis,Tennis Women's Singles,NA
+Moiss Rodriques Duque,M,27,173,75,Brazil,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Guillermo Durn,M,28,178,82,Argentina-2,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Miguel Durn Navia,M,20,193,80,Spain,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Miguel Durn Navia,M,20,193,80,Spain,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,NA
+Yordanys Duraona Garca,M,28,185,83,Dominica,2016 Summer,Athletics,Athletics Men's Triple Jump,NA
+Kevin Wayne Durant,M,27,206,105,United States,2016 Summer,Basketball,Basketball Men's Basketball,Gold
+Scott David Durant,M,28,196,96,Great Britain,2016 Summer,Rowing,Rowing Men's Coxed Eights,Gold
+Marina Durunda,F,19,170,51,Azerbaijan,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Individual,NA
+Andrew Durutalo,M,28,188,107,United States,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Nadiya Dusanova,F,28,174,56,Uzbekistan,2016 Summer,Athletics,Athletics Women's High Jump,NA
+Hasanboy Dusmatov,M,23,156,49,Uzbekistan,2016 Summer,Boxing,Boxing Men's Light-Flyweight,Gold
+Sardorbek Dusmurotov,M,23,168,110,Uzbekistan,2016 Summer,Weightlifting,Weightlifting Men's Super-Heavyweight,NA
+Stuart Dutamby,M,22,176,74,France,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Pamela Dutkiewicz,F,24,170,61,Germany,2016 Summer,Athletics,Athletics Women's 100 metres Hurdles,NA
+Rogrio Dutra Silva,M,32,178,73,Brazil,2016 Summer,Tennis,Tennis Men's Singles,NA
+Yogeshwar Dutt,M,33,168,65,India,2016 Summer,Wrestling,"Wrestling Men's Welterweight, Freestyle",NA
+Phillip Peter Dutton,M,52,168,68,United States,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",Bronze
+Phillip Peter Dutton,M,52,168,68,United States,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Domagoj Duvnjak,M,28,198,100,Croatia,2016 Summer,Handball,Handball Men's Handball,NA
+Ann-Sophie Duyck,F,29,172,60,Belgium,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Ann-Sophie Duyck,F,29,172,60,Belgium,2016 Summer,Cycling,Cycling Women's Individual Time Trial,NA
+Sultan Duzelbayev,M,22,176,46,Kazakhstan,2016 Summer,Archery,Archery Men's Individual,NA
+Kristijan urasek,M,29,170,57,Croatia,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Filip Dvok,M,28,189,89,Czech Republic,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, 1,000 metres",NA
+"Galyna Volodymyrivna ""Galia"" Dvorak Khasanova",F,28,169,58,Spain,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+iva Dvorak,F,25,168,70,Slovenia,2016 Summer,Shooting,"Shooting Women's Air Rifle, 10 metres",NA
+iva Dvorak,F,25,168,70,Slovenia,2016 Summer,Shooting,"Shooting Women's Small-Bore Rifle, Three Positions, 50 metres",NA
+Conor James Dwyer,M,27,196,89,United States,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,Bronze
+Conor James Dwyer,M,27,196,89,United States,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Conor James Dwyer,M,27,196,89,United States,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,Gold
+Jamie Raymond Dwyer,M,37,172,68,Australia,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Kirstin Sheree Dwyer,F,27,173,66,Australia,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Yekaterina Vladimirovna Dyachenko,F,28,167,53,Russia,2016 Summer,Fencing,"Fencing Women's Sabre, Individual",NA
+Yekaterina Vladimirovna Dyachenko,F,28,167,53,Russia,2016 Summer,Fencing,"Fencing Women's Sabre, Team",Gold
+Ivan Fyodorovich Dychko,M,25,205,91,Kazakhstan,2016 Summer,Boxing,Boxing Men's Super-Heavyweight,Bronze
+Agnieszka Dygacz,F,31,160,47,Poland,2016 Summer,Athletics,Athletics Women's 20 kilometres Walk,NA
+Chlo Dygert (-Owen),F,19,176,66,United States,2016 Summer,Cycling,Cycling Women's Team Pursuit,Silver
+Jakub Dyjas,M,20,183,54,Poland,2016 Summer,Table Tennis,Table Tennis Men's Singles,NA
+Jakub Dyjas,M,20,183,54,Poland,2016 Summer,Table Tennis,Table Tennis Men's Team,NA
+Emma Dyke,F,21,181,68,New Zealand,2016 Summer,Rowing,Rowing Women's Coxed Eights,NA
+Bakhodir Dzhalolov,M,22,198,100,Uzbekistan,2016 Summer,Boxing,Boxing Men's Super-Heavyweight,NA
+Rustam Dzhangabayev,M,22,183,147,Uzbekistan,2016 Summer,Weightlifting,Weightlifting Men's Super-Heavyweight,NA
+Martynas Diaugys,M,29,189,95,Lithuania,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,NA
+Edyta Dzieniszewska-Kierkla,F,30,170,72,Poland,2016 Summer,Canoeing,"Canoeing Women's Kayak Fours, 500 metres",NA
+Chido Dzingirai,F,24,172,69,Zimbabwe,2016 Summer,Football,Football Women's Football,NA
+Adrian Dziko,M,26,169,65,Poland,2016 Summer,Badminton,Badminton Men's Singles,NA
+Damir Dumhur,M,24,175,65,Bosnia and Herzegovina,2016 Summer,Tennis,Tennis Men's Singles,NA
+Casey Eastham-Sablowski,F,27,170,62,Australia,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Ashton James Eaton,M,28,186,81,United States,2016 Summer,Athletics,Athletics Men's Decathlon,Gold
+Milad Ebadipour Gharahassanlou,M,22,202,78,Iran,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Yuki Ebihara,F,30,164,68,Japan,2016 Summer,Athletics,Athletics Women's Javelin Throw,NA
+Masashi Ebinuma,M,26,170,66,Japan,2016 Summer,Judo,Judo Men's Half-Lightweight,Bronze
+Nate Ebner,M,27,185,98,United States,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Katie Rae Ebzery,F,26,178,70,Australia,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Fernando Echavarri Erasum,M,43,180,76,Spain,2016 Summer,Sailing,Sailing Mixed Multihull,NA
+Iera Echebarra Fernndez,F,23,160,63,Spain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Tmara Echegoyen Domnguez,F,32,174,70,Spain,2016 Summer,Sailing,Sailing Women's Skiff,NA
+Gonzalo Echenique Saglietti,M,26,190,94,Spain,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Gregory Joshue Echenique Carrillo,M,25,206,137,Venezuela,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Isabella Echeverri Restrepo,F,22,172,66,Colombia,2016 Summer,Football,Football Women's Football,NA
+Lisa Ecker,F,23,157,55,Austria,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Lisa Ecker,F,23,157,55,Austria,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Lisa Ecker,F,23,157,55,Austria,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Lisa Ecker,F,23,157,55,Austria,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Ludovico Edalli,M,22,165,57,Italy,2016 Summer,Gymnastics,Gymnastics Men's Individual All-Around,NA
+Ludovico Edalli,M,22,165,57,Italy,2016 Summer,Gymnastics,Gymnastics Men's Floor Exercise,NA
+Ludovico Edalli,M,22,165,57,Italy,2016 Summer,Gymnastics,Gymnastics Men's Parallel Bars,NA
+Ludovico Edalli,M,22,165,57,Italy,2016 Summer,Gymnastics,Gymnastics Men's Horizontal Bar,NA
+Ludovico Edalli,M,22,165,57,Italy,2016 Summer,Gymnastics,Gymnastics Men's Rings,NA
+Ludovico Edalli,M,22,165,57,Italy,2016 Summer,Gymnastics,Gymnastics Men's Pommelled Horse,NA
+"Jessica Jane ""Jess"" Eddie",F,31,178,75,Great Britain,2016 Summer,Rowing,Rowing Women's Coxed Eights,Silver
+Offiong Edem,F,29,170,70,Nigeria,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+der Francis Carbonera,M,32,205,107,Brazil,2016 Summer,Volleyball,Volleyball Men's Volleyball,Gold
+"Alexander ""Alex"" Edmondson",M,22,184,76,Australia,2016 Summer,Cycling,"Cycling Men's Team Pursuit, 4,000 metres",Silver
+Annette Edmondson,F,24,171,65,Australia,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Annette Edmondson,F,24,171,65,Australia,2016 Summer,Cycling,Cycling Women's Omnium,NA
+Kyle Edmund,M,21,188,80,Great Britain,2016 Summer,Tennis,Tennis Men's Singles,NA
+"Madeleine ""Maddie"" Edmunds",F,24,187,81,Australia,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,NA
+Muktar Edris Awel,M,22,171,60,Ethiopia,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+Alonso Reno Edward Henry,M,26,181,76,Panama,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Julia Edward,F,25,166,57,New Zealand,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Batrice Edwige,F,27,182,76,France,2016 Summer,Handball,Handball Women's Handball,Silver
+Britt Eerland,F,22,168,62,Netherlands,2016 Summer,Table Tennis,Table Tennis Women's Team,NA
+Riau Ega Agatha,M,24,175,70,Indonesia,2016 Summer,Archery,Archery Men's Individual,NA
+Riau Ega Agatha,M,24,175,70,Indonesia,2016 Summer,Archery,Archery Men's Team,NA
+Paola Ogechi Egonu,F,17,190,70,Italy,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Naiara Egozkue Extremado,F,32,173,70,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+Viktria Egri,F,18,168,57,Hungary,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Ogho-Ogene Omano Egwero,M,27,171,72,Nigeria,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Naito Ehara,M,23,172,59,Japan,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Naito Ehara,M,23,172,59,Japan,2016 Summer,Swimming,Swimming Men's 4 x 200 metres Freestyle Relay,Bronze
+Casey Eichfeld,M,26,178,77,United States,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",NA
+Casey Eichfeld,M,26,178,77,United States,2016 Summer,Canoeing,"Canoeing Men's Canadian Doubles, Slalom",NA
+Kiana Eide,F,17,160,54,United States,2016 Summer,Rhythmic Gymnastics,Rhythmic Gymnastics Women's Group,NA
+Joachim Eilers,M,26,185,90,Germany,2016 Summer,Cycling,Cycling Men's Sprint,NA
+Joachim Eilers,M,26,185,90,Germany,2016 Summer,Cycling,Cycling Men's Keirin,NA
+Joachim Eilers,M,26,185,90,Germany,2016 Summer,Cycling,Cycling Men's Team Sprint,NA
+Eslam Eissa,M,28,190,90,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Tracy Eisser,F,26,185,84,United States,2016 Summer,Rowing,Rowing Women's Quadruple Sculls,NA
+Michaela Ek,F,36,174,68,Sweden,2016 Summer,Handball,Handball Women's Handball,NA
+Seluk Eker,M,24,163,52,Turkey,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Matilda Ekholm,F,34,172,67,Sweden,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Deep Grace Ekka,F,22,158,63,India,2016 Summer,Hockey,Hockey Women's Hockey,NA
+Yekaterina Aleksandrovna Ektova,F,23,170,59,Kazakhstan,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+Khalid El-Aabidi,M,20,178,85,Morocco,2016 Summer,Weightlifting,Weightlifting Men's Light-Heavyweight,NA
+El Hassan El-Abbassi,M,32,171,61,Bahrain,2016 Summer,Athletics,"Athletics Men's 10,000 metres",NA
+Ahmed Moustafa Nasr El-Ahmar,M,32,181,79,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Marwan Ahmed Aly Morsy El-Amrawy,M,21,194,93,Egypt,2016 Summer,Swimming,Swimming Men's 10 kilometres Open Water,NA
+Nour El-Ayoubi,F,19,167,58,Egypt,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Soufiane El-Bakkali,M,20,188,62,Morocco,2016 Summer,Athletics,"Athletics Men's 3,000 metres Steeplechase",NA
+Abdelkhalek El-Banna,M,28,193,95,Egypt,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Mohamed Hashim Ahmad El-Bassiouny,M,26,186,82,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Nadeen Ahmad Ali El-Dawlatly,F,23,162,54,Egypt,2016 Summer,Table Tennis,Table Tennis Women's Singles,NA
+Nadeen Ahmad Ali El-Dawlatly,F,23,162,54,Egypt,2016 Summer,Table Tennis,Table Tennis Women's Team,NA
+Yehia El-Deraa,M,21,186,82,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Amro Abdulrahman Ali El-Geziry,M,29,185,75,Egypt,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Omar El-Geziry,M,31,185,77,Egypt,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Doaa El-Ghobashy,F,19,180,74,Egypt,2016 Summer,Beach Volleyball,Beach Volleyball Women's Beach Volleyball,NA
+Ali Saleh El-Ghrari,M,19,NA,NA,Libya,2016 Summer,Archery,Archery Men's Individual,NA
+Abdelati El-Guesse,M,23,187,64,Morocco,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Abdelmajid El-Hissouf,M,23,170,56,Morocco,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Afaf Muhammad El-Hodhod,F,19,163,75,Egypt,2016 Summer,Shooting,"Shooting Women's Air Pistol, 10 metres",NA
+Afaf Muhammad El-Hodhod,F,19,163,75,Egypt,2016 Summer,Shooting,"Shooting Women's Sporting Pistol, 25 metres",NA
+Fouad El-Kaam,M,28,188,70,Morocco,2016 Summer,Athletics,"Athletics Men's 1,500 metres",NA
+Marwan Mohamed Ismail Mohamed Aly El-Kamash,M,22,183,77,Egypt,2016 Summer,Swimming,Swimming Men's 200 metres Freestyle,NA
+Marwan Mohamed Ismail Mohamed Aly El-Kamash,M,22,183,77,Egypt,2016 Summer,Swimming,Swimming Men's 400 metres Freestyle,NA
+Mohamed El-Hadi Yussif El-Kawisah,M,29,NA,NA,Libya,2016 Summer,Judo,Judo Men's Extra-Lightweight,NA
+Ahmed El-Kotb,M,25,197,80,Egypt,2016 Summer,Volleyball,Volleyball Men's Volleyball,NA
+Jomana El-Maghrabi,F,21,162,50,Egypt,2016 Summer,Synchronized Swimming,Synchronized Swimming Women's Team,NA
+Messaoud El-Mahadi,M,26,168,59,Morocco,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Greco-Roman",NA
+Ibrahim El-Masry,M,27,195,100,Egypt,2016 Summer,Handball,Handball Men's Handball,NA
+Jidou Ould Khaye El-Moctar,M,31,171,72,Mauritania,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+Ahmed Mahmud Muhammad Saleh El-Nemr,M,37,183,84,Egypt,2016 Summer,Archery,Archery Men's Individual,NA
+Hamdy Moustafa El-Said Abdelwahab,M,23,171,96,Egypt,2016 Summer,Wrestling,"Wrestling Men's Heavyweight, Greco-Roman",NA
+Seham Muhammad Ahmad El-Sawalhy,F,25,175,65,Egypt,2016 Summer,Taekwondo,Taekwondo Women's Welterweight,NA
+Karim Emad El-Sayed,M,21,183,87,Egypt,2016 Summer,Canoeing,"Canoeing Men's Kayak Singles, 200 metres",NA
+Ashraf Amgad El-Seify,M,21,185,105,Qatar,2016 Summer,Athletics,Athletics Men's Hammer Throw,NA
+Fatma Nagib El-Sharnouby,F,18,NA,NA,Egypt,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Islam Amru Abdallah Ahmad El-Shehaby,M,34,195,105,Egypt,2016 Summer,Judo,Judo Men's Heavyweight,NA
+Sherine Ahmed El-Zeiny,F,25,162,50,Egypt,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Sherine Ahmed El-Zeiny,F,25,162,50,Egypt,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Sherine Ahmed El-Zeiny,F,25,162,50,Egypt,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Sherine Ahmed El-Zeiny,F,25,162,50,Egypt,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Karim Ahmad Rafa't El-Zoghby,M,39,178,70,Egypt,2016 Summer,Equestrianism,"Equestrianism Mixed Jumping, Individual",NA
+Jenny Elbe,F,26,180,64,Germany,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+"Robert ""Rob"" Elder",M,35,194,115,Fiji,2016 Summer,Archery,Archery Men's Individual,NA
+Antri Eleftheriou,F,32,162,50,Cyprus,2016 Summer,Shooting,Shooting Women's Skeet,NA
+Franck Dannique Elemba Owaka,M,26,198,130,Congo (Brazzaville),2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Stefaniya Aleksandrovna Elfutina,F,19,170,59,Russia,2016 Summer,Sailing,Sailing Women's Windsurfer,Bronze
+Gasto Jos Ministro Elias,M,25,183,76,Portugal,2016 Summer,Tennis,Tennis Men's Singles,NA
+Gasto Jos Ministro Elias,M,25,183,76,Portugal,2016 Summer,Tennis,Tennis Men's Doubles,NA
+Nacif Elias,M,27,172,78,Lebanon,2016 Summer,Judo,Judo Men's Half-Middleweight,NA
+Alberth Josu Elis Martnez,M,20,184,77,Honduras,2016 Summer,Football,Football Men's Football,NA
+Peter Taua Elisa Henry,M,25,170,82,Cook Islands,2016 Summer,Sailing,Sailing Men's One Person Dinghy,NA
+Valentina Neli Elisei (Ardean-),F,34,172,64,Romania,2016 Summer,Handball,Handball Women's Handball,NA
+"Walton Glenn Eller, III",M,34,188,82,United States,2016 Summer,Shooting,Shooting Men's Double Trap,NA
+James Lee Ellington,M,30,179,81,Great Britain,2016 Summer,Athletics,Athletics Men's 100 metres,NA
+James Lee Ellington,M,30,179,81,Great Britain,2016 Summer,Athletics,Athletics Men's 4 x 100 metres Relay,NA
+Burkheart Ellis Jr.,M,23,191,85,Barbados,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Lauren Ellis,F,27,166,64,New Zealand,2016 Summer,Cycling,Cycling Women's Team Pursuit,NA
+Lauren Ellis,F,27,166,64,New Zealand,2016 Summer,Cycling,Cycling Women's Omnium,NA
+Marcus John Ellis,M,26,175,80,Great Britain,2016 Summer,Badminton,Badminton Men's Doubles,Bronze
+Taylor Ellis-Watson,F,23,183,65,United States,2016 Summer,Athletics,Athletics Women's 4 x 400 metres Relay,Gold
+Brady Lee Ellison,M,27,181,86,United States,2016 Summer,Archery,Archery Men's Individual,Bronze
+Brady Lee Ellison,M,27,181,86,United States,2016 Summer,Archery,Archery Men's Team,Silver
+"Daxenos Richard Ren ""Dex"" Elmont",M,32,175,73,Netherlands,2016 Summer,Judo,Judo Men's Lightweight,NA
+Amanda Elmore,F,25,180,80,United States,2016 Summer,Rowing,Rowing Women's Coxed Eights,Gold
+Brittany Joyce Elmslie,F,22,179,73,Australia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Freestyle Relay,Gold
+Brittany Joyce Elmslie,F,22,179,73,Australia,2016 Summer,Swimming,Swimming Women's 4 x 100 metres Medley Relay,Silver
+Patricia Elorza Eguiara,F,32,180,78,Spain,2016 Summer,Handball,Handball Women's Handball,NA
+Ander Elosegi Alkain,M,28,186,80,Spain,2016 Summer,Canoeing,"Canoeing Men's Canadian Singles, Slalom",NA
+Gracie Elvin,F,27,175,65,Australia,2016 Summer,Cycling,"Cycling Women's Road Race, Individual",NA
+Gvrise Emane,F,34,162,70,France,2016 Summer,Judo,Judo Women's Middleweight,NA
+Irina Embrich (Zamkovaja-),F,36,170,54,Estonia,2016 Summer,Fencing,"Fencing Women's epee, Individual",NA
+Irina Embrich (Zamkovaja-),F,36,170,54,Estonia,2016 Summer,Fencing,"Fencing Women's epee, Team",NA
+"Mitchell ""Mitch"" Emery",M,25,185,89,Australia,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Elas Eliseo Emigdio Abarca,M,25,165,52,Mexico,2016 Summer,Boxing,Boxing Men's Flyweight,NA
+Ion Emilianov,M,39,202,165,Moldova,2016 Summer,Athletics,Athletics Men's Shot Put,NA
+Msipa Emmaculate,F,24,168,59,Zimbabwe,2016 Summer,Football,Football Women's Football,NA
+Crystal Emmanuel,F,24,170,59,Canada,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Crystal Emmanuel,F,24,170,59,Canada,2016 Summer,Athletics,Athletics Women's 200 metres,NA
+Crystal Emmanuel,F,24,170,59,Canada,2016 Summer,Athletics,Athletics Women's 4 x 100 metres Relay,NA
+Giulia Enrica Emmolo,F,24,171,67,Italy,2016 Summer,Water Polo,Water Polo Women's Water Polo,Silver
+"Matthew D. ""Matt"" Emmons",M,35,175,84,United States,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Esteban Jos Enderica Salgado,M,25,177,71,Ecuador,2016 Summer,Swimming,"Swimming Men's 1,500 metres Freestyle",NA
+Esteban Jos Enderica Salgado,M,25,177,71,Ecuador,2016 Summer,Swimming,Swimming Men's 10 kilometres Open Water,NA
+Ren Enders,M,29,165,77,Germany,2016 Summer,Cycling,Cycling Men's Team Sprint,NA
+Hiroyuki Endo,M,29,171,72,Japan,2016 Summer,Badminton,Badminton Men's Doubles,NA
+Wataru Endo,M,23,178,73,Japan,2016 Summer,Football,Football Men's Football,NA
+Tnu Endrekson,M,37,198,104,Estonia,2016 Summer,Rowing,Rowing Men's Quadruple Sculls,Bronze
+Whitney Elizabeth Engen,F,28,170,65,United States,2016 Summer,Football,Football Women's Football,NA
+Mark English,M,23,187,76,Ireland,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Tobias Englmaier,M,28,158,63,Germany,2016 Summer,Judo,Judo Men's Extra-Lightweight,NA
+Sofia Ennaoui,F,20,158,42,Poland,2016 Summer,Athletics,"Athletics Women's 1,500 metres",NA
+Jessica Phyllis Ennis-Hill,F,30,165,57,Great Britain,2016 Summer,Athletics,Athletics Women's Heptathlon,Silver
+Stephanie Marie Enright,F,25,179,56,Puerto Rico,2016 Summer,Volleyball,Volleyball Women's Volleyball,NA
+Sergi Enrique Montserrat,M,28,174,69,Spain,2016 Summer,Hockey,Hockey Men's Hockey,NA
+Manuel Benjamn Enzema Owo,M,27,170,63,Equatorial Guinea,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Gwladys Patience pangue,F,32,178,88,France,2016 Summer,Taekwondo,Taekwondo Women's Heavyweight,NA
+Olivia poupa,F,22,164,53,France,2016 Summer,Basketball,Basketball Women's Basketball,NA
+Christina Epps,F,25,175,66,United States,2016 Summer,Athletics,Athletics Women's Triple Jump,NA
+Orukpe Eraiyokan,M,22,180,73,Nigeria,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Arsen Kadyrbayevich Eraliyev,M,26,165,59,Kyrgyzstan,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Greco-Roman",NA
+Douglas John Erasmus,M,26,182,78,South Africa,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,NA
+Amaia Erbina Araa,F,19,171,68,Spain,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,NA
+Abby May Erceg,F,26,177,68,New Zealand,2016 Summer,Football,Football Women's Football,NA
+Balzs Erdlyi,M,26,196,94,Hungary,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Zsfia Erdlyi,F,28,164,53,Hungary,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Erdenebatyn Bekhbayar,M,23,161,62,Mongolia,2016 Summer,Wrestling,"Wrestling Men's Featherweight, Freestyle",NA
+Erdenebatyn Tsendbaatar,M,19,163,56,Mongolia,2016 Summer,Boxing,Boxing Men's Bantamweight,NA
+Erdenechimegiin Sumiya,F,26,159,53,Mongolia,2016 Summer,Wrestling,"Wrestling Women's Featherweight, Freestyle",NA
+Mria rdi,F,18,175,65,Hungary,2016 Summer,Sailing,Sailing Women's One Person Dinghy,NA
+"Meryem (Mariam-) Erdoan (Tanga-, Hana Dingo-)",F,26,172,55,Turkey,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Ebi Ere,M,35,196,97,Nigeria,2016 Summer,Basketball,Basketball Men's Basketball,NA
+Robin Erewa,M,25,184,80,Germany,2016 Summer,Athletics,Athletics Men's 200 metres,NA
+Fie Udby Erichsen,F,31,184,79,Denmark,2016 Summer,Rowing,Rowing Women's Single Sculls,NA
+"Christopher ""Chris"" Erickson",M,34,175,60,Australia,2016 Summer,Athletics,Athletics Men's 50 kilometres Walk,NA
+Berit Lisa Matilda Ericson,F,28,165,60,Sweden,2016 Summer,Sailing,Sailing Women's Skiff,NA
+rika Cristiano dos Santos,F,28,172,55,Brazil,2016 Summer,Football,Football Women's Football,NA
+rika Cristina de Souza,F,34,196,92,Brazil,2016 Summer,Basketball,Basketball Women's Basketball,NA
+"Magdalena ""Magda"" Eriksson",F,22,172,66,Sweden,2016 Summer,Football,Football Women's Football,Silver
+Sandra Elisabeth Eriksson,F,27,163,47,Finland,2016 Summer,Athletics,"Athletics Women's 3,000 metres Steeplechase",NA
+Saturday Keigo Erimuya,M,18,171,NA,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Sara Errani,F,29,164,58,Italy,2016 Summer,Tennis,Tennis Women's Singles,NA
+Sara Errani,F,29,164,58,Italy,2016 Summer,Tennis,Tennis Women's Doubles,NA
+Arianna Errigo,F,28,180,68,Italy,2016 Summer,Fencing,"Fencing Women's Foil, Individual",NA
+Hakan Ereker,M,22,168,60,Qatar,2016 Summer,Boxing,Boxing Men's Lightweight,NA
+Anthony Lee Ervin,M,35,191,80,United States,2016 Summer,Swimming,Swimming Men's 50 metres Freestyle,Gold
+Anthony Lee Ervin,M,35,191,80,United States,2016 Summer,Swimming,Swimming Men's 4 x 100 metres Freestyle Relay,Gold
+Imanol Erviti Ollo,M,32,190,80,Spain,2016 Summer,Cycling,"Cycling Men's Road Race, Individual",NA
+Youns Es-Salhi,M,23,180,64,Morocco,2016 Summer,Athletics,"Athletics Men's 5,000 metres",NA
+"Srgio ""Escadinha"" Dutra dos Santos",M,40,184,78,Brazil,2016 Summer,Volleyball,Volleyball Men's Volleyball,Gold
+Mara Alexandra Escobar Guerrero,F,36,161,58,Ecuador,2016 Summer,Weightlifting,Weightlifting Women's Lightweight,NA
+Catalina Elena Escobar Gmez,F,25,156,50,Colombia,2016 Summer,Gymnastics,Gymnastics Women's Individual All-Around,NA
+Catalina Elena Escobar Gmez,F,25,156,50,Colombia,2016 Summer,Gymnastics,Gymnastics Women's Floor Exercise,NA
+Catalina Elena Escobar Gmez,F,25,156,50,Colombia,2016 Summer,Gymnastics,Gymnastics Women's Uneven Bars,NA
+Catalina Elena Escobar Gmez,F,25,156,50,Colombia,2016 Summer,Gymnastics,Gymnastics Women's Balance Beam,NA
+Kristine Esebua,F,31,162,69,Georgia,2016 Summer,Archery,Archery Women's Individual,NA
+Kristine Esebua,F,31,162,69,Georgia,2016 Summer,Archery,Archery Women's Team,NA
+Ricardo de Sousa Esgaio,M,23,175,80,Portugal,2016 Summer,Football,Football Men's Football,NA
+Shitaye Eshete Habtegebrel,F,26,164,51,Bahrain,2016 Summer,Athletics,Athletics Women's Marathon,NA
+Zhuldyz Attakurovna Eshimova (Turtbaeva-),F,28,152,48,Kazakhstan,2016 Summer,Wrestling,"Wrestling Women's Flyweight, Freestyle",NA
+Jess Espaa Cobo,M,37,168,59,Spain,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Albert Espaol Lifante,M,30,189,86,Spain,2016 Summer,Water Polo,Water Polo Men's Water Polo,NA
+Anna Espar Llaquet,F,23,180,66,Spain,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Clara Espar Llaquet,F,21,178,68,Spain,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Jaime Yusept Espinal Fajardo,M,31,178,86,Puerto Rico,2016 Summer,Wrestling,"Wrestling Men's Light-Heavyweight, Freestyle",NA
+Rodolfo Marcelo Espinal Paniagua,M,23,175,78,Honduras,2016 Summer,Football,Football Men's Football,NA
+Maricet Espinosa Gonzlez,F,26,163,63,Cuba,2016 Summer,Judo,Judo Women's Half-Middleweight,NA
+Paola Milagros Espinosa Snchez,F,30,156,48,Mexico,2016 Summer,Diving,Diving Women's Platform,NA
+Paola Milagros Espinosa Snchez,F,30,156,48,Mexico,2016 Summer,Diving,Diving Women's Synchronized Platform,NA
+Yaniuska Isabel Espinosa,F,29,172,114,Venezuela,2016 Summer,Weightlifting,Weightlifting Women's Super-Heavyweight,NA
+Ahymara del Carmen Espinoza Echenique,F,31,170,80,Venezuela,2016 Summer,Athletics,Athletics Women's Shot Put,NA
+Cristian Omar Espinoza,M,21,173,70,Argentina,2016 Summer,Football,Football Men's Football,NA
+Mara del Rosario Espinoza Espinoza,F,28,173,70,Mexico,2016 Summer,Taekwondo,Taekwondo Women's Heavyweight,Silver
+Chloe Esposito,F,24,168,55,Australia,2016 Summer,Modern Pentathlon,Modern Pentathlon Women's Individual,Gold
+Max Esposito,M,19,174,64,Australia,2016 Summer,Modern Pentathlon,Modern Pentathlon Men's Individual,NA
+Jhonatan Esquivel Montes de Oca,M,27,183,86,Uruguay,2016 Summer,Rowing,Rowing Men's Single Sculls,NA
+Iman Essa Jasim,F,19,NA,NA,Bahrain,2016 Summer,Athletics,Athletics Women's 100 metres,NA
+Mohamed Essam Al-Din Hassanain,M,21,180,74,Egypt,2016 Summer,Fencing,"Fencing Men's Foil, Individual",NA
+Mohamed Essam Al-Din Hassanain,M,21,180,74,Egypt,2016 Summer,Fencing,"Fencing Men's Foil, Team",NA
+Joseph milienne Essombe Tiako,F,28,159,55,Cameroon,2016 Summer,Wrestling,"Wrestling Women's Featherweight, Freestyle",NA
+Hederson Alves Estefani,M,24,183,65,Brazil,2016 Summer,Athletics,Athletics Men's 400 metres,NA
+Juan Pablo Estelles,M,28,187,91,Argentina,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Laura Ester Ramos,F,26,170,58,Spain,2016 Summer,Water Polo,Water Polo Women's Water Polo,NA
+Tewelde Estifanos Hidru,M,34,NA,NA,Eritrea,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Reinier Estpinan Gmez,M,33,170,72,Cuba,2016 Summer,Shooting,"Shooting Men's Air Rifle, 10 metres",NA
+Reinier Estpinan Gmez,M,33,170,72,Cuba,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Three Positions, 50 metres",NA
+Reinier Estpinan Gmez,M,33,170,72,Cuba,2016 Summer,Shooting,"Shooting Men's Small-Bore Rifle, Prone, 50 metres",NA
+Daniel Estrada Coz,M,26,173,61,Chile,2016 Summer,Athletics,Athletics Men's Marathon,NA
+Magdiel Estrada Cala,M,21,176,73,Cuba,2016 Summer,Judo,Judo Men's Lightweight,NA
+Vctor Estrella Burgos,M,36,173,77,Dominican Republic,2016 Summer,Tennis,Tennis Men's Singles,NA
+Rodrigo Etchart,M,22,175,80,Argentina,2016 Summer,Rugby Sevens,Rugby Sevens Men's Rugby Sevens,NA
+Oghenekaro Peter Etebo,M,20,172,71,Nigeria,2016 Summer,Football,Football Men's Football,Bronze
+Brice Pascal Guy Ets,M,32,185,73,Monaco,2016 Summer,Athletics,Athletics Men's 800 metres,NA
+Gemma Etheridge,F,29,169,66,Australia,2016 Summer,Rugby Sevens,Rugby Sevens Women's Rugby Sevens,Gold
+Takashi Eto,M,25,183,67,Japan,2016 Summer,Athletics,Athletics Men's High Jump,NA
+Nour Elhouda Ettaieb,F,19,170,57,Tunisia,2016 Summer,Rowing,Rowing Women's Lightweight Double Sculls,NA
+Johan Magnus Eurn,M,31,192,120,Sweden,2016 Summer,Wrestling,"Wrestling Men's Super-Heavyweight, Greco-Roman",NA
+Evandro Gonalves Oliveira Jnior,M,26,210,105,Brazil-2,2016 Summer,Beach Volleyball,Beach Volleyball Men's Beach Volleyball,NA
+Andrew Evans,M,25,198,114,United States,2016 Summer,Athletics,Athletics Men's Discus Throw,NA
+Blair Catherine Evans,F,25,175,65,Australia,2016 Summer,Swimming,Swimming Women's 400 metres Individual Medley,NA
+Joanna Evans,F,19,180,66,Bahamas,2016 Summer,Swimming,Swimming Women's 200 metres Freestyle,NA
+Joanna Evans,F,19,180,66,Bahamas,2016 Summer,Swimming,Swimming Women's 400 metres Freestyle,NA
+Joanna Evans,F,19,180,66,Bahamas,2016 Summer,Swimming,Swimming Women's 800 metres Freestyle,NA
+Jonty Evans,M,44,193,82,Ireland,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Individual",NA
+Jonty Evans,M,44,193,82,Ireland,2016 Summer,Equestrianism,"Equestrianism Mixed Three-Day Event, Team",NA
+Kyle Jordan S. Evans,M,22,180,81,Great Britain,2016 Summer,Cycling,Cycling Men's BMX,NA
+Scott Evans,M,28,182,78,Ireland,2016 Summer,Badminton,Badminton Men's Singles,NA
+Ciara Everard,F,26,169,54,Ireland,2016 Summer,Athletics,Athletics Women's 800 metres,NA
+Nelson vora,M,32,183,76,Portugal,2016 Summer,Athletics,Athletics Men's Triple Jump,NA

--- a/seeders.js
+++ b/seeders.js
@@ -1,0 +1,43 @@
+var fs = require('fs');
+var csv =  require('fast-csv');
+const pg = require('pg')
+var config = {
+  user: "manojpanta",
+  database: "koroibos_development",
+  password: null,
+  port: 5432,
+  host: "localhost"
+}
+const pool = new pg.Pool(config);
+
+pool.connect(function(err) {
+  if (err) {
+    console.log(err);
+  }
+});
+
+let counter = 1;
+let csvStream = csv.fromPath("./public/files/olympions.csv", {headers: true})
+.on('data', (record)=>  {
+  csvStream.pause();
+  let id = counter;
+  let name = record.Name;
+  let team = record.Team;
+  let age = record.Age;
+  let sport = record.Sport;
+  let createdAt = new Date();
+  let updatedAt =  new Date();
+  pool.query("INSERT INTO Olympians (id,name,team,age,sport,createdAt,updatedAt) \ VALUES($1,$2,$3,$4,$5,$6,$7)", [id,name,team,age,sport,createdAt,updatedAt], function(err) {
+    if (err) {
+      console.log(err);
+    }
+  });
+  counter ++;
+  csvStream.resume();
+})
+.on('end',function(end) {
+  console.log('Finised Importing')
+})
+.on('err',function(err) {
+  console.log(err);
+})

--- a/seeders/20190603023015-olympions_seed.js
+++ b/seeders/20190603023015-olympions_seed.js
@@ -1,0 +1,10 @@
+'use strict';
+var fs = require('fs');
+var csv =  require('fast-csv');
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.bulkDelete('olympians', null, {});
+  }
+};


### PR DESCRIPTION
Create seeders.js file to import datas from ./public/files/olympion.csv, successfully imports

- Created `olympians` table in DB
- Created `seeder.js` file to import csv files to `db`
- Imported `olympion.csv` file and populated `olympians` table
- Table `olympians` has `name`,`team`, `age`, and `sport` columns